### PR TITLE
New index() method to find handlers 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 1.6
 * Run tests on older python as well
 * Support for dataclass (Since python 3.7)
+* Added methods to find the appropriate handlers
 
 1.5
 * Improve handling of unions

--- a/tests/test_datadumper.py
+++ b/tests/test_datadumper.py
@@ -112,6 +112,12 @@ class TestHandlers(unittest.TestCase):
         dumper.raiseconditionerrors = False
         assert dumper.dump(1) == 1
 
+    def test_replace_handler(self):
+        dumper = datadumper.Dumper()
+        index = dumper.index([])
+        dumper.handlers[index] = (dumper.handlers[index][0], lambda *args: 3)
+        assert dumper.dump(12) == 3
+
 
 class TestDumper(unittest.TestCase):
 

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -192,3 +192,14 @@ class TestEnum(unittest.TestCase):
         with self.assertRaises(ValueError):
             loader.load(2, TestEnum)
         assert loader.load(['2', 1], Tuple[TestEnum, TestEnum]) == (TestEnum.LABEL2, TestEnum.LABEL1)
+
+
+class TestLoaderIndex(unittest.TestCase):
+
+    def test_removal(self):
+
+        loader = dataloader.Loader()
+        assert loader.load(3, int) == 3
+        loader.handlers.pop(loader.index(int))
+        with self.assertRaises(TypeError):
+            loader.load(3, int)

--- a/typedload/datadumper.py
+++ b/typedload/datadumper.py
@@ -100,17 +100,29 @@ class Dumper:
         for k, v in kwargs.items():
             setattr(self, k, v)
 
-    def dump(self, value: Any) -> Any:
-        for cond, func in self.handlers:
+
+    def index(self, value: Any) -> int:
+        """
+        Returns the index in the handlers list
+        that matches the given value.
+
+        If no condition matches, ValueError is raised.
+        """
+        for i, cond in ((j[0], j[1][0]) for j in enumerate(self.handlers)):
             try:
-                r = cond(value)
+                match = cond(value)
             except:
                 if self.raiseconditionerrors:
                     raise
-                r = False
-            if r:
-                return func(self, value)
+                match = False
+            if match:
+                return i
         raise ValueError('Unable to dump %s' % value)
+
+    def dump(self, value: Any) -> Any:
+        index = self.index(value)
+        func = self.handlers[index][1]
+        return func(self, value)
 
 
 def _namedtupledump(l, value):


### PR DESCRIPTION
New index() method to find handlers ￼…
The handlers list contains tuples of condition and actual handler.

It is very useful to manipulate it to add new types.

However when it is desirable to replace an handler, it might be difficult to find it, without
directly going into the code, and the ordering of the handlers might change.

This API allows the users to find handlers, and perhaps replace them, or know their position
to add other handlers before or after that position.