### PR TITLE
Add a loadtrace to exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.7-dev"
 
 install:
-  - pip install mypy
+  - pip install mypy==0.620
 
 script:
   - make test

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 1.9
 * Support ForwardRef
+* Add a new Exception type with more details on the error (no breaking API changes)
 
 1.8
 * Make mypy happy again

--- a/tests/test_attrload.py
+++ b/tests/test_attrload.py
@@ -137,3 +137,23 @@ class TestMangling(unittest.TestCase):
 
     def test_dump_metanames(self):
         assert attrdump(Mangle(12)) == {'va.lue': 12}
+
+
+class TestAttrExceptions(unittest.TestCase):
+
+    def test_index(self):
+        try:
+            attrload(
+                {
+                    'course': 'advanced coursing',
+                    'students': [
+                        {'name': 'Alfio'},
+                        {'name': 'Carmelo', 'address': 'via mulino'},
+                        [],
+                    ]
+                },
+                Students,
+            )
+        except Exception as e:
+            assert e.trace[-2].annotation[1] == 'students'
+            assert e.trace[-1].annotation[1] == 2

--- a/typedload/datadumper.py
+++ b/typedload/datadumper.py
@@ -22,6 +22,8 @@
 from enum import Enum
 from typing import *
 
+from .exceptions import TypedloadValueError
+
 
 __all__ = [
     'Dumper',
@@ -117,7 +119,7 @@ class Dumper:
                 match = False
             if match:
                 return i
-        raise ValueError('Unable to dump %s' % value)
+        raise TypedloadValueError('Unable to dump %s' % value, value=value)
 
     def dump(self, value: Any) -> Any:
         index = self.index(value)

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -359,7 +359,7 @@ def _namedtupleload(l: Loader, value: Dict[str, Any], type_) -> Tuple:
         params[k] = l.load(
             v,
             type_hints[k],
-            annotation=(AnnotationType.FIELD, k),
+            annotation=Annotation(AnnotationType.FIELD, k),
         )
     return type_(**params)
 

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -214,7 +214,7 @@ class Loader:
                 match = False
             if match:
                 return i
-        raise TypedloadValueError('No matching condition found')
+        raise ValueError('No matching condition found')
 
     def load(self, value: Any, type_: Type[T], *, annotation: Optional[Annotation] = None) -> T:
         """

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -262,14 +262,15 @@ def _forwardrefload(l: Loader, value: Any, type_: type) -> Any:
     """
     if l.frefs is None:
         raise TypedloadException('ForwardRef resolving is disabled for the loader', value=value, type_=type_)
-    t = l.frefs.get(type_.__forward_arg__)  # type: ignore
+    tname = type_.__forward_arg__  # type: ignore
+    t = l.frefs.get(tname)
     if t is None:
         raise TypedloadValueError(
-            "ForwardRef '%s' unknown" % type_.__forward_arg__,  # type: ignore
+            "ForwardRef '%s' unknown" % tname,
             value=value,
             type_=type_
         )
-    return l.load(value, t, annotation=(AnnotationType.FORWARDREF, type_.__forward_arg__))
+    return l.load(value, t, annotation=Annotation(AnnotationType.FORWARDREF, tname))
 
 
 def _basicload(l: Loader, value: Any, type_: type) -> Any:

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -238,7 +238,7 @@ class Loader:
         try:
             return func(self, value, type_)
         except TypedloadException as e:
-            e.trace.append(TraceItem(value, type_, annotation))
+            e.trace.insert(0, TraceItem(value, type_, annotation))
             raise e
 
 
@@ -346,7 +346,6 @@ def _namedtupleload(l: Loader, value: Dict[str, Any], type_) -> Tuple:
     try:
         vfields = set(value.keys())
     except AttributeError as e:
-        print(e)
         raise TypedloadAttributeError(str(e), value=value, type_=type_)
 
     if necessary_fields.intersection(vfields) != necessary_fields:

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -226,7 +226,11 @@ class Loader:
         try:
             index = self.index(type_)
         except ValueError:
-            raise TypedloadTypeError('Cannot deal with value %s of type %s' % (value, type_))
+            raise TypedloadTypeError(
+                'Cannot deal with value of type %s' % type_,
+                value=value,
+                type_=type_
+            )
 
         # Add type to known types, to resolve ForwardRef later on
         if self.frefs is not None and hasattr(type_, '__name__'):

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -241,16 +241,10 @@ class Loader:
         func = self.handlers[index][1]
         try:
             return func(self, value, type_)
-        except TypedloadException as e:
+        except Exception as e:
+            assert isinstance(e, TypedloadException)
             e.trace.insert(0, TraceItem(value, type_, annotation))
             raise e
-        except Exception as e:
-            # This is a bug.
-            raise TypedloadException(
-                '==== SOFTWARE BUG ====: %s. Non TypedloadException encountered' % e,
-                type_=type_,
-                value=value,
-            )
 
 
 def _forwardrefload(l: Loader, value: Any, type_: type) -> Any:

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -233,7 +233,13 @@ class Loader:
                 self.frefs[tname] = type_
 
         func = self.handlers[index][1]
-        return func(self, value, type_)
+        try:
+            return func(self, value, type_)
+        except Exception as e:
+            loadtrace = getattr(e, 'loadtrace', [])
+            loadtrace.append((value, type_))
+            setattr(e, 'loadtrace', loadtrace)
+            raise e
 
 
 def _forwardrefload(l: Loader, value: Any, type_: type) -> Any:

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -22,7 +22,7 @@
 from enum import Enum
 from typing import *
 
-from .exceptions import Annotation, AnnotationType
+from .exceptions import Annotation, AnnotationType, TraceItem
 
 
 __all__ = [
@@ -239,7 +239,7 @@ class Loader:
             return func(self, value, type_)
         except Exception as e:
             loadtrace = getattr(e, 'loadtrace', [])
-            loadtrace.append((value, type_, annotation))
+            loadtrace.append(TraceItem(value, type_, annotation))
             setattr(e, 'loadtrace', loadtrace)
             raise e
 

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -343,7 +343,11 @@ def _namedtupleload(l: Loader, value: Dict[str, Any], type_) -> Tuple:
         optional_fields ={k for k,v in type_.__dataclass_fields__.items() if not isinstance (getattr(v, 'default', dataclasses._MISSING_TYPE()), dataclasses._MISSING_TYPE)}
         type_hints = {k: v.type for k,v in type_.__dataclass_fields__.items()}
     necessary_fields = fields.difference(optional_fields)
-    vfields = set(value.keys())
+    try:
+        vfields = set(value.keys())
+    except AttributeError as e:
+        print(e)
+        raise TypedloadAttributeError(str(e), value=value, type_=type_)
 
     if necessary_fields.intersection(vfields) != necessary_fields:
         raise TypedloadValueError(

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -20,14 +20,22 @@
 
 
 from enum import Enum
-from typing import NamedTuple, Union
+from typing import Any, NamedTuple, Optional, Type, Union
 
 
 class AnnotationType(Enum):
     FIELD = 'field'
     INDEX = 'index'
 
+
 Annotation = NamedTuple('Annotation', [
     ('annotation_type', AnnotationType),
     ('value', Union[str, int]),
+])
+
+
+TraceItem = NamedTuple('TraceItem', [
+    ('value', Any),
+    ('type', Type),
+    ('annotation', Optional[Annotation]),
 ])

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -81,7 +81,7 @@ class TypedloadException(Exception):
             description: str,
             trace: Optional[List[TraceItem]] = None,
             value=None,
-            type_: Optional[Type] = None,
+            type_: Optional[Any] = None,  # Any should be Type, but that raises an exception in python 3.5.2
             exceptions: Optional[List[Exception]] = None) -> None:
         super().__init__(description)
         self.trace = trace if trace else []

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -20,11 +20,14 @@
 
 
 from enum import Enum
-from typing import Tuple, Union
+from typing import NamedTuple, Union
 
 
 class AnnotationType(Enum):
     FIELD = 'field'
     INDEX = 'index'
 
-Annotation = Tuple[AnnotationType, Union[str, int]]
+Annotation = NamedTuple('Annotation', [
+    ('annotation_type', AnnotationType),
+    ('value', Union[str, int]),
+])

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -1,0 +1,30 @@
+# typedload
+# Exceptions
+
+# Copyright (C) 2018 Salvo "LtWorf" Tomaselli
+#
+# typedload is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# author Salvo "LtWorf" Tomaselli <tiposchi@tiscali.it>
+
+
+from enum import Enum
+from typing import Tuple, Union
+
+
+class AnnotationType(Enum):
+    FIELD = 'field'
+    INDEX = 'index'
+
+Annotation = Tuple[AnnotationType, Union[str, int]]

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -42,7 +42,7 @@ Annotation = NamedTuple('Annotation', [
 
 TraceItem = NamedTuple('TraceItem', [
     ('value', Any),
-    ('type', Type),
+    ('type_', Type),
     ('annotation', Optional[Annotation]),
 ])
 

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -20,7 +20,7 @@
 
 
 from enum import Enum
-from typing import Any, NamedTuple, Optional, Type, Union
+from typing import Any, List, NamedTuple, Optional, Type, Union
 
 
 class AnnotationType(Enum):
@@ -39,3 +39,27 @@ TraceItem = NamedTuple('TraceItem', [
     ('type', Type),
     ('annotation', Optional[Annotation]),
 ])
+
+
+class TypedloadException(Exception):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.trace = []  # type: List[TraceItem]
+        self.value = kwargs.get('value')  # type: Any
+        self.type_ = kwargs.get('type_')  # type: Optional[Type]
+        self.exceptions = kwargs.get('exceptions', [])  # type: List[Exception]
+
+
+class TypedloadValueError(TypedloadException, ValueError):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
+class TypedloadTypeError(TypedloadException, TypeError):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
+class TypedloadAttributeError(TypedloadException, AttributeError):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -79,6 +79,25 @@ class TypedloadException(Exception):
         self.type_ = kwargs.get('type_')  # type: Optional[Type]
         self.exceptions = kwargs.get('exceptions', [])  # type: List[Exception]
 
+    def __str__(self) -> str:
+        def compress_value(v: Any) -> str:
+            v = str(v)
+            if len(v) > 80:
+                return v[:77] + '...'
+            return v
+        e = '%s\nValue: %s\nType: %s\n' % (
+            super().__str__(),
+            compress_value(self.value),
+            self.type_
+        )
+        e += '\nLoad trace:\n'
+        for i in self.trace:
+            e += 'Type: %s ' % i.type_
+            if i.annotation:
+                e += 'Annotation: (%s %s) ' % (i.annotation[0], i.annotation[1])
+            e += 'Value: %s\n' % compress_value(i.value)
+        return e
+
 
 class TypedloadValueError(TypedloadException, ValueError):
     """

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -24,6 +24,12 @@ from typing import Any, List, NamedTuple, Optional, Type, Union
 
 
 class AnnotationType(Enum):
+    """
+    The types of annotation, used by different loaders.
+
+    FIELD is the name of a field
+    INDEX is the numerical index of a value, in subscriptable objects-
+    """
     FIELD = 'field'
     INDEX = 'index'
 
@@ -42,6 +48,30 @@ TraceItem = NamedTuple('TraceItem', [
 
 
 class TypedloadException(Exception):
+    """
+    Exception which exposes some extra fields.
+
+    trace:
+        It is a list of all the recursive invocations of load(), with the
+        parameters used.
+        Very useful to locate the issue.
+        The annotation is used by complex loaders that call load() more than
+        once, to indicate in which step the error occurred.
+        For example a list loader will use it to indicate the index which had
+        the exception, and a NamedTuple loader will use it to indicate the name
+        of the field which generated the exception.
+
+    value:
+        contains the value that could not be loaded.
+
+    type_:
+        contains the type in which the value could not be loaded.
+
+    exceptions:
+        A list of exceptions that happened during the loading.
+        This is for now only used by the Union loader, to list all the
+        exceptions that occurred during the various attempts.
+    """
     def __init__(self, *args, **kwargs):
         super().__init__(*args)
         self.trace = []  # type: List[TraceItem]
@@ -51,15 +81,27 @@ class TypedloadException(Exception):
 
 
 class TypedloadValueError(TypedloadException, ValueError):
+    """
+    Exception class, subclass of ValueError.
+    See the documentation of TypedloadException for more details.
+    """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
 
 class TypedloadTypeError(TypedloadException, TypeError):
+    """
+    Exception class, subclass of TypeError.
+    See the documentation of TypedloadException for more details.
+    """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
 
 class TypedloadAttributeError(TypedloadException, AttributeError):
+    """
+    Exception class, subclass of AttributeError.
+    See the documentation of TypedloadException for more details.
+    """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -43,7 +43,7 @@ TraceItem = NamedTuple('TraceItem', [
 
 class TypedloadException(Exception):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(*args)
         self.trace = []  # type: List[TraceItem]
         self.value = kwargs.get('value')  # type: Any
         self.type_ = kwargs.get('type_')  # type: Optional[Type]

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -33,6 +33,9 @@ class AnnotationType(Enum):
     FIELD = 'field'
     INDEX = 'index'
     FORWARDREF = 'forwardref'
+    KEY = 'key'
+    VALUE = 'value'
+    UNION = 'union'
 
 
 Annotation = NamedTuple('Annotation', [

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -76,12 +76,18 @@ class TypedloadException(Exception):
         This is for now only used by the Union loader, to list all the
         exceptions that occurred during the various attempts.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args)
-        self.trace = []  # type: List[TraceItem]
-        self.value = kwargs.get('value')  # type: Any
-        self.type_ = kwargs.get('type_')  # type: Optional[Type]
-        self.exceptions = kwargs.get('exceptions', [])  # type: List[Exception]
+    def __init__(
+            self,
+            description: str,
+            trace: Optional[List[TraceItem]] = None,
+            value=None,
+            type_: Optional[Type] = None,
+            exceptions: Optional[List[Exception]] = None) -> None:
+        super().__init__(description)
+        self.trace = trace if trace else []
+        self.value = value
+        self.type_ = type_
+        self.exceptions = exceptions if exceptions else []
 
     def __str__(self) -> str:
         def compress_value(v: Any) -> str:

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -96,11 +96,20 @@ class TypedloadException(Exception):
         )
         if self.trace:
             e += '\nLoad trace:\n'
+        path = []  # type: List[str]
         for i in self.trace:
             e += 'Type: %s ' % i.type_
             if i.annotation:
                 e += 'Annotation: (%s %s) ' % (i.annotation[0], i.annotation[1])
+                path.append(i.annotation[1] if type(i.annotation[1]) != int else '[%d]' % i.annotation[1])  # type: ignore
+            else:
+                path.append(str(None))
             e += 'Value: %s\n' % compress_value(i.value)
+        if path:
+            if path[0] == str(None):
+                path[0] = ''
+            e += 'Path: ' + '.'.join(path) + '\n'
+
         return e
 
 

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -90,7 +90,8 @@ class TypedloadException(Exception):
             compress_value(self.value),
             self.type_
         )
-        e += '\nLoad trace:\n'
+        if self.trace:
+            e += '\nLoad trace:\n'
         for i in self.trace:
             e += 'Type: %s ' % i.type_
             if i.annotation:

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -32,6 +32,7 @@ class AnnotationType(Enum):
     """
     FIELD = 'field'
     INDEX = 'index'
+    FORWARDREF = 'forwardref'
 
 
 Annotation = NamedTuple('Annotation', [

--- a/typedload/plugins/attrload.py
+++ b/typedload/plugins/attrload.py
@@ -32,6 +32,7 @@
 
 
 from ..dataloader import _namedtupleload
+from ..exceptions import *
 
 class _FakeNamedTuple(tuple):
     """
@@ -60,7 +61,12 @@ class _FakeNamedTuple(tuple):
         return self[2]
 
     def __call__(self, **kwargs):
-        return self[3](**kwargs)
+        try:
+            return self[3](**kwargs)
+        except TypeError as e:
+            raise TypedloadTypeError(str(e), type_=self[3], value=kwargs)
+        except Exception as e:
+            raise TypedloadException(str(e), type_=self[3], value=kwargs)
 
 
 def _attrload(l, value, type_):


### PR DESCRIPTION
When an exception is raised, it is caught by the load() function, which
appends to a list the type and value that it was called with.

So at the end the exception has a trace of all the sub-types where the exception
occurred.

Closes: #31 