### PR TITLE
Fix the possible annotation value ￼…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 1.11
+* Fixed problem when printing sub-exceptions of failed unions
 
 1.10
 * Make mypy happy again

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+1.11
+
 1.10
 * Make mypy happy again
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+typedload (1.11-1) UNRELEASED; urgency=medium
+
+  * New upstream release
+
+ -- Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>  Sat, 13 Oct 2018 03:21:54 +0200
+
 typedload (1.10-1) unstable; urgency=low
 
   * New upstream release

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from distutils.core import setup
 
 setup(
     name='typedload',
-    version='1.10',
+    version='1.11',
     description='Load and dump data from json-like format into typed data structures',
     long_description='''Manipulating data loaded from json is very error prone.
 

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -40,7 +40,7 @@ class AnnotationType(Enum):
 
 Annotation = NamedTuple('Annotation', [
     ('annotation_type', AnnotationType),
-    ('value', Union[str, int, Type]),
+    ('value', Union[str, int, Type[Any]]),
 ])
 
 

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -40,7 +40,7 @@ class AnnotationType(Enum):
 
 Annotation = NamedTuple('Annotation', [
     ('annotation_type', AnnotationType),
-    ('value', Union[str, int, Type[Any]]),
+    ('value', Any),  # Actually Union[str, int, Type], but python 3.5.2 is idiotic
 ])
 
 

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -107,7 +107,7 @@ class TypedloadException(Exception):
             e += 'Type: %s ' % i.type_
             if i.annotation:
                 e += 'Annotation: (%s %s) ' % (i.annotation[0], i.annotation[1])
-                path.append(str(i.annotation[1]) if type(i.annotation[1]) != int else '[%d]' % i.annotation[1])  # type: ignore
+                path.append(str(i.annotation[1]) if type(i.annotation[1]) != int else '[%d]' % i.annotation[1])
             else:
                 path.append(str(None))
             e += 'Value: %s\n' % compress_value(i.value)

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -40,7 +40,7 @@ class AnnotationType(Enum):
 
 Annotation = NamedTuple('Annotation', [
     ('annotation_type', AnnotationType),
-    ('value', Union[str, int]),
+    ('value', Union[str, int, Type]),
 ])
 
 
@@ -107,7 +107,7 @@ class TypedloadException(Exception):
             e += 'Type: %s ' % i.type_
             if i.annotation:
                 e += 'Annotation: (%s %s) ' % (i.annotation[0], i.annotation[1])
-                path.append(i.annotation[1] if type(i.annotation[1]) != int else '[%d]' % i.annotation[1])  # type: ignore
+                path.append(str(i.annotation[1]) if type(i.annotation[1]) != int else '[%d]' % i.annotation[1])  # type: ignore
             else:
                 path.append(str(None))
             e += 'Value: %s\n' % compress_value(i.value)


### PR DESCRIPTION
In the case of unions, annotation values are types, so that was failing the string conversion of
the sub-exceptions of the union.