### PR TITLE
Use setuptools instead of distutils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.7-dev"
 
 install:
-  - pip install mypy
+  - pip install mypy setuptools
 
 script:
   - make test

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: typedload
 Section: python
 Priority: optional
 Maintainer: Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>
-Build-Depends: debhelper (>= 11), python3, dh-python, python3-distutils,
+Build-Depends: debhelper (>= 11), python3, dh-python, python3-setuptools,
  mypy (= 0.641-1)
 Standards-Version: 4.2.1
 Homepage: https://github.com/ltworf/typedload#typedload

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@
 #
 # author Salvo "LtWorf" Tomaselli <tiposchi@tiscali.it>
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='typedload',


### PR DESCRIPTION
PPUG [recommends](https://packaging.python.org/guides/tool-recommendations/#packaging-tool-recommendations) using setuptools.

Additionally this would make it easier to use typedload as a dependency from git thanks to the egg support. Specifically for myself I would like to be able to include typedload as a git requirement using poetry, but this fails because `setup.py egg_info` is not supported.