### PR TITLE
Relax mypy version dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
 typedload (1.11-1) UNRELEASED; urgency=medium
 
   * New upstream release
+  * Relax mypy dependency version (Closes: #916280)
 
- -- Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>  Wed, 17 Oct 2018 20:12:39 +0200
+ -- Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>  Sat, 15 Dec 2018 15:12:39 +0100
 
 typedload (1.10-2) unstable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: python
 Priority: optional
 Maintainer: Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>
 Build-Depends: debhelper (>= 11), python3, dh-python, python3-distutils,
- mypy (= 0.641-1)
+ mypy (>= 0.641)
 Standards-Version: 4.2.1
 Homepage: https://github.com/ltworf/typedload#typedload
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
I hope it won't cause any more build failures on new versions.