### PR TITLE
Raise the proper exception when passing crap to attrload

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 1.13
+* Fix bug in loading attr classes and passing random crap.
+  Now the proper exception is raised.
 
 1.12
 * Support fields with factory for dataclass

--- a/tests/test_attrload.py
+++ b/tests/test_attrload.py
@@ -1,5 +1,5 @@
 # typedload
-# Copyright (C) 2018 Salvo "LtWorf" Tomaselli
+# Copyright (C) 2018-2019 Salvo "LtWorf" Tomaselli
 #
 # typedload is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/test_attrload.py
+++ b/tests/test_attrload.py
@@ -22,7 +22,7 @@ import unittest
 
 import attr
 
-from typedload import attrload, attrdump
+from typedload import attrload, attrdump, exceptions
 from typedload import datadumper
 from typedload.plugins import attrdump as attrplugin
 
@@ -140,6 +140,24 @@ class TestMangling(unittest.TestCase):
 
 
 class TestAttrExceptions(unittest.TestCase):
+
+    def test_wrongtype(self):
+        try:
+            attrload(3, Person)
+        except exceptions.TypedloadTypeError:
+            pass
+
+        data = {
+            'course': 'how to be a corsair',
+            'students': [
+                {'name': 'Alfio'},
+                3
+            ]
+        }
+        try:
+            attrload(data, Students)
+        except exceptions.TypedloadTypeError as e:
+            assert e.trace[-1].annotation[1] == 1
 
     def test_index(self):
         try:

--- a/typedload/plugins/attrload.py
+++ b/typedload/plugins/attrload.py
@@ -72,6 +72,8 @@ class _FakeNamedTuple(tuple):
 
 
 def _attrload(l, value, type_):
+    if not isinstance(value, dict):
+        raise TypedloadTypeError('Expected dictionary, got %s' % type(value), type_=type_, value=value)
     value = value.copy()
     names = []
     defaults = {}

--- a/typedload/plugins/attrload.py
+++ b/typedload/plugins/attrload.py
@@ -15,7 +15,7 @@ can't be used in variable names.
 Another common application is to convert camelCase into not_camel_case.
 """
 
-# Copyright (C) 2018 Salvo "LtWorf" Tomaselli
+# Copyright (C) 2018-2019 Salvo "LtWorf" Tomaselli
 #
 # typedload is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Otherwise the exception won't contain the trace.