### PR TITLE
Correct exception when loading a non iterable into a list

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 1.16
 * New uniontypes() function.
+* Make list and dictionary loaders raise the correct exceptions
 
 1.15
 * Add support for FrozenSet[T].

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -22,7 +22,7 @@ from enum import Enum
 from typing import Dict, List, NamedTuple, Optional, Set, Tuple, Union
 import unittest
 
-from typedload import dataloader, load
+from typedload import dataloader, load, exceptions
 
 
 class TestRealCase(unittest.TestCase):
@@ -259,6 +259,11 @@ class TestLoaderIndex(unittest.TestCase):
 
 
 class TestExceptions(unittest.TestCase):
+
+    def test_list_exception(self):
+        loader = dataloader.Loader()
+        with self.assertRaises(exceptions.TypedloadTypeError):
+            loader.load(None, List[int])
 
     def test_index(self):
         loader = dataloader.Loader()

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -265,6 +265,11 @@ class TestExceptions(unittest.TestCase):
         with self.assertRaises(exceptions.TypedloadTypeError):
             loader.load(None, List[int])
 
+    def test_dict_exception(self):
+        loader = dataloader.Loader()
+        with self.assertRaises(exceptions.TypedloadAttributeError):
+            loader.load(None, Dict[int, int])
+
     def test_index(self):
         loader = dataloader.Loader()
         try:

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -270,8 +270,12 @@ def _listload(l: Loader, value, type_) -> List:
     This loads into something like List[int]
     """
     t = type_.__args__[0]
-    return [l.load(v, t, annotation=Annotation(AnnotationType.INDEX, i)) for i, v in enumerate(value)]
-
+    try:
+        return [l.load(v, t, annotation=Annotation(AnnotationType.INDEX, i)) for i, v in enumerate(value)]
+    except TypeError as e:
+        if isinstance(e, TypedloadException):
+            raise
+        raise TypedloadTypeError(str(e), value=value, type_=type_)
 
 def _dictload(l: Loader, value, type_) -> Dict:
     """


### PR DESCRIPTION
Fixes: https://github.com/ltworf/typedload/issues/79