### PR TITLE
args.Namespace → dict

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 1.16
 * New uniontypes() function.
 * Make list and dictionary loaders raise the correct exceptions
+* Able to load from argparse.Namespace
 
 1.15
 * Add support for FrozenSet[T].

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -17,6 +17,7 @@
 # author Salvo "LtWorf" Tomaselli <tiposchi@tiscali.it>
 
 
+import argparse
 import datetime
 from enum import Enum
 from typing import Dict, List, NamedTuple, Optional, Set, Tuple, Union
@@ -328,3 +329,22 @@ class TestDatetime(unittest.TestCase):
         assert loader.load((15, 33, 0), datetime.time) == datetime.time(15, 33)
         assert loader.load((2011, 1, 1), datetime.datetime) == datetime.datetime(2011, 1, 1)
         assert loader.load((2011, 1, 1, 22), datetime.datetime) == datetime.datetime(2011, 1, 1, 22)
+
+
+class TestDictEquivalence(unittest.TestCase):
+
+    def test_namespace(self):
+        loader = dataloader.Loader()
+        data = argparse.Namespace(a=12, b='33')
+        class A(NamedTuple):
+            a: int
+            b: int
+            c: int = 1
+        assert loader.load(data, A) == A(12, 33, 1)
+        assert loader.load(data, Dict[str, int]) == {'a': 12, 'b': 33}
+
+    def test_nonamespace(self):
+        loader = dataloader.Loader(dictequivalence=False)
+        data = argparse.Namespace(a=1)
+        with self.assertRaises(AttributeError):
+            loader.load(data, Dict[str, int])

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -277,6 +277,7 @@ def _listload(l: Loader, value, type_) -> List:
             raise
         raise TypedloadTypeError(str(e), value=value, type_=type_)
 
+
 def _dictload(l: Loader, value, type_) -> Dict:
     """
     This loads into something like Dict[str,str]
@@ -290,7 +291,6 @@ def _dictload(l: Loader, value, type_) -> Dict:
             for k, v in value.items()}
     except AttributeError as e:
         raise TypedloadAttributeError(str(e), type_=type_, value=value)
-
 
 
 def _setload(l: Loader, value, type_) -> Set:

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -63,6 +63,13 @@ class Loader:
         If you know that your original data is encoded
         properly, it is better to disable this.
 
+    dictequivalence: Enabled by default.
+        Automatically convert dict-like classes to dictionary
+        when loading. This enables them to be loaded into other
+        classes.
+        At the moment it supports:
+            argparse.Namespace
+
     raiseconditionerrors: Enabled by default.
         Raises exceptions when evaluating a condition from an
         handler. When disabled, the exceptions are not raised
@@ -147,7 +154,8 @@ class Loader:
         # Forward refs dictionary
         self.frefs = {}  # type: Optional[Dict[str, Type]]
 
-
+        # Enable conversion of dict-like things to dicts, before loading
+        self.dictequivalence = True
 
         # The list of handlers to use to load the data.
         # It gets iterated in order, and the first condition
@@ -212,6 +220,12 @@ class Loader:
                 self.frefs[tname] = type_
 
         func = self.handlers[index][1]
+
+        if self.dictequivalence:
+            # Convert argparse.Namespace to dictionary
+            if hasattr(value, '_get_kwargs'):
+                value = {k: v for k,v in value._get_kwargs()}
+
         try:
             return func(self, value, type_)
         except Exception as e:


### PR DESCRIPTION
This converts `args.Namespace` classes to dictionaries, so they can be used by handlers which expect a dictionary.

The feature is enabled by default, but can be toggled.