### PR TITLE
Run tests on all supported python versions

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,8 @@
 
 override_dh_auto_test:
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
-	make test
 	make mypy
+	for pyversion in `py3versions -s`; do \
+		$$pyversion -m tests; \
+	done
 endif


### PR DESCRIPTION
When building the debian package, this will run the tests on all supported
python3 versions rather than just the default one.

Closes: #27