### PR TITLE
Sort union types

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 1.17
+* Prefer the same type in union loading
 
 1.16
 * New uniontypes() function.

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -80,6 +80,19 @@ class TestRealCase(unittest.TestCase):
 
 
 class TestUnion(unittest.TestCase):
+    def test_json(self):
+        '''
+        This test would normally be flaky, but with the scoring of
+        types in union, it should always work.
+        '''
+        Json = Union[int, float, str, bool, None, List['Json'], Dict[str, 'Json']]
+        data = [{},[]]
+
+        loader = dataloader.Loader()
+        loader.basiccast = False
+        loader.frefs = {'Json' : Json}
+
+        assert loader.load(data, Json) == data
 
     def test_ComplicatedUnion(self):
         class A(NamedTuple):

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -436,20 +436,19 @@ def _unionload(l: Loader, value, type_) -> Any:
     exceptions = []
 
     # Give a score to the types
-    scored = []  # type: List[Tuple[int, Type]]
+    sorted_args = []  # type: List[Type]
     for t in args:
         if (value_type == list and is_list(t)) or \
            (value_type == dict and is_dict(t)) or \
            (value_type == frozenset and is_frozenset(t)) or \
            (value_type == set and is_set(t)) or \
            (value_type == tuple and is_tuple(t)):
-            score = 1
+            sorted_args.insert(0, t)
         else:
-            score = 0
-        scored.append((score, t))
+            sorted_args.append(t)
 
     # Try all types
-    for _, t in sorted(scored, key= lambda x: x[0], reverse=True):
+    for t in sorted_args:
         try:
             return l.load(value, t, annotation=Annotation(AnnotationType.UNION, t))
         except Exception as e:

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -427,20 +427,22 @@ def _unionload(l: Loader, value, type_) -> Any:
     except AttributeError:
         raise TypedloadAttributeError('The typing API for this Python version is unknown')
 
+    value_type = type(value)
+
     # Do not convert basic types, if possible
-    if type(value) in args.intersection(l.basictypes):
+    if value_type in args.intersection(l.basictypes):
         return value
 
     exceptions = []
 
-    # Give a score to the types, [ (score, type), ... ]
+    # Give a score to the types
     scored = []  # type: List[Tuple[int, Type]]
     for t in args:
-        if (type(value) == list and is_list(t)) or \
-           (type(value) == dict and is_dict(t)) or \
-           (type(value) == frozenset and is_frozenset(t)) or \
-           (type(value) == set and is_set(t)) or \
-           (type(value) == tuple and is_tuple(t)):
+        if (value_type == list and is_list(t)) or \
+           (value_type == dict and is_dict(t)) or \
+           (value_type == frozenset and is_frozenset(t)) or \
+           (value_type == set and is_set(t)) or \
+           (value_type == tuple and is_tuple(t)):
             score = 1
         else:
             score = 0

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -433,8 +433,21 @@ def _unionload(l: Loader, value, type_) -> Any:
 
     exceptions = []
 
-    # Try all types
+    # Give a score to the types, [ (score, type), ... ]
+    scored: List[Tuple[int, Type]] = []
     for t in args:
+        if (type(value) == list and is_list(t)) or \
+           (type(value) == dict and is_dict(t)) or \
+           (type(value) == frozenset and is_frozenset(t)) or \
+           (type(value) == set and is_set(t)) or \
+           (type(value) == tuple and is_tuple(t)):
+            score = 1
+        else:
+            score = 0
+        scored.append((score, t))
+
+    # Try all types
+    for _, t in sorted(scored, key= lambda x: x[0], reverse=True):
         try:
             return l.load(value, t, annotation=Annotation(AnnotationType.UNION, t))
         except Exception as e:

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -434,7 +434,7 @@ def _unionload(l: Loader, value, type_) -> Any:
     exceptions = []
 
     # Give a score to the types, [ (score, type), ... ]
-    scored: List[Tuple[int, Type]] = []
+    scored = []  # type: List[Tuple[int, Type]]
     for t in args:
         if (type(value) == list and is_list(t)) or \
            (type(value) == dict and is_dict(t)) or \


### PR DESCRIPTION
To prefer types that are more similar to the value which is being passed.

So in case of types that are very similar and would both work, the most similar one is preferred.

Fixes: #87