### PR TITLE
Document name mangling

### DIFF
--- a/typedload/__init__.py
+++ b/typedload/__init__.py
@@ -105,9 +105,30 @@ This can of course be used also for use cases that make sense.
 
 The handlers must generate exceptions from the typedload.exceptions
 module.
+
+
+Name mangling
+=============
+
+Name mangling is supported in datatypes with metadata (dataclass, attrs) by
+having a 'name' key in the metadata.
+
+@attr.s
+class Example:
+    attribute = attr.ib(type=int, metadata={'name': 'att.rib.ute:name'}
+
+@dataclass
+class Example():
+  attribute: str = field(metadata={'name': 'att.rib.ute:name'})
+
+The dictionary key for 'attribute' will be 'att.rib.ute:name'.
+
+This is very useful for keys that use invalid or reserved characters that
+can't be used in variable names.
+Another common application is to convert camelCase into not_camel_case.
 """
 
-# Copyright (C) 2018 Salvo "LtWorf" Tomaselli
+# Copyright (C) 2018-2019 Salvo "LtWorf" Tomaselli
 #
 # typedload is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/typedload/plugins/attrdump.py
+++ b/typedload/plugins/attrdump.py
@@ -1,21 +1,9 @@
 """
 typedload
 Module to load data into data structures from the "attr" module
-
-Name mangling is supported by having a 'name' attribute in the metadata
-
-@attr.s
-class Example:
-    attribute = attr.ib(type=int, metadata={'name': 'att.rib.ute:name'}
-
-The dictionary key for 'attribute' will be 'att.rib.ute:name'.
-
-This is very useful for keys that use invalid or reserved characters that
-can't be used in variable names.
-Another common application is to convert camelCase into not_camel_case.
 """
 
-# Copyright (C) 2018 Salvo "LtWorf" Tomaselli
+# Copyright (C) 2018-2019 Salvo "LtWorf" Tomaselli
 #
 # typedload is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/typedload/plugins/attrload.py
+++ b/typedload/plugins/attrload.py
@@ -1,18 +1,6 @@
 """
 typedload
 Module to load data into data structures from the "attr" module
-
-Name mangling is supported by having a 'name' attribute in the metadata
-
-@attr.s
-class Example:
-    attribute = attr.ib(type=int, metadata={'name': 'att.rib.ute:name'}
-
-The dictionary key for 'attribute' will be 'att.rib.ute:name'.
-
-This is very useful for keys that use invalid or reserved characters that
-can't be used in variable names.
-Another common application is to convert camelCase into not_camel_case.
 """
 
 # Copyright (C) 2018-2019 Salvo "LtWorf" Tomaselli


### PR DESCRIPTION
It was only documented for attrs, but not for dataclass. Move it into the
main docstring.

Closes: #91