### PR TITLE
dpkg-buildpackage does source-only

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 1.18
 * Improved documentation
+* Debian builds are now done source only
 
 1.17
 * Prefer the same type in union loading

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ deb-pkg: dist
 	mv typedload_`./setup.py --version`.orig.tar.gz* /tmp
 	cd /tmp; tar -xf typedload_*.orig.tar.gz
 	cp -r debian /tmp/typedload/
-	cd /tmp/typedload/; dpkg-buildpackage
+	cd /tmp/typedload/; dpkg-buildpackage --changes-option=-S
 	mkdir deb-pkg
 	mv /tmp/typedload_* /tmp/python3-typedload_*.deb deb-pkg
 	$(RM) -r /tmp/typedload


### PR DESCRIPTION
This is required to make typedload go to testing.