### PR TITLE
Bump mypy

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ typedload (1.19-1) UNRELEASED; urgency=medium
 
   * New upstream release
   * Bump compat to 12
+  * Bump mypy minimum version
 
  -- Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>  Sun, 15 Sep 2019 14:07:18 +0200
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: python
 Priority: optional
 Maintainer: Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>
 Build-Depends: debhelper (>= 12), python3, dh-python, python3-distutils,
- mypy (>= 0.641)
+ mypy (>= 0.740)
 Standards-Version: 4.4.0
 Homepage: https://github.com/ltworf/typedload#typedload
 Vcs-Browser: https://github.com/ltworf/typedload

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -174,7 +174,7 @@ class Loader:
             (is_dataclass, _namedtupleload),
             (is_forwardref, _forwardrefload),
             (lambda type_: type_ in {datetime.date, datetime.time, datetime.datetime}, _datetimeload),
-        ]  # type: List[Tuple[Callable[[Type[T]], bool], Callable[['Loader', Any, Type[T]], T]]]
+        ]
 
         for k, v in kwargs.items():
             setattr(self, k, v)
@@ -227,7 +227,7 @@ class Loader:
                 value = {k: v for k,v in value._get_kwargs()}
 
         try:
-            return func(self, value, type_)
+            return cast(T, func(self, value, type_))
         except Exception as e:
             assert isinstance(e, TypedloadException)
             e.trace.insert(0, TraceItem(value, type_, annotation))


### PR DESCRIPTION
The new mypy version has improved checks on callables signatures.

The error it gives is correct but  the code actually works because the types of the functions are checked before calling the function itself, so the resulting type actually matches.

This makes it shut up.

