### PR TITLE
Use __annotations__ instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 dist: xenial
 python:
   - "3.5"
-  - "3.5.2"
   - "3.6"
   - "3.7"
   - "3.8-dev"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 1.20
+* Drop support for Python 3.5.2 (3.5 series is still supported)
 
 1.19
 * Add support for Literal.

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ like json, because it guarantees that the data will have the expected format.
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     keywords='typing types mypy json',
     packages=['typedload', 'typedload.plugins'],

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -363,7 +363,7 @@ def _namedtupleload(l: Loader, value: Dict[str, Any], type_) -> Tuple:
     if not hasattr(type_, '__dataclass_fields__'):
         fields = set(type_._fields)
         optional_fields = set(getattr(type_, '_field_defaults', {}).keys())
-        type_hints = type_._field_types
+        type_hints = type_.__annotations__
     else:
         #dataclass
         import dataclasses

--- a/typedload/plugins/attrload.py
+++ b/typedload/plugins/attrload.py
@@ -44,7 +44,7 @@ class _FakeNamedTuple(tuple):
         return self[0]
 
     @property
-    def _field_types(self):
+    def __annotations__(self):
         return self[1]
 
     @property

--- a/typedload/typechecks.py
+++ b/typedload/typechecks.py
@@ -177,7 +177,7 @@ def is_namedtuple(type_: Type[Any]) -> bool:
     '''
     Generated with typing.NamedTuple
     '''
-    return _issubclass(type_, tuple) and hasattr(type_, '_field_types') and hasattr(type_, '_fields')
+    return _issubclass(type_, tuple) and hasattr(type_, '__annotations__') and hasattr(type_, '_fields')
 
 
 def is_dataclass(type_: Type[Any]) -> bool:


### PR DESCRIPTION
_field_types was deprecated in Python3.8, better move to use annotations.

Drop support for Python 3.5.2

Python 3.5.2 is outdated, the typing module was experimental and
supporting it introduces hacks.

It is still used by Ubuntu Xenial, however popcon indicates 0 installs
of this package on Ubuntu, so it seems safe to drop.

An up-to-date Python 3.5 install is still supported, just the very old
3.5.2 is being dropped.



Closes: #98