### PR TITLE
Cache the index() function

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 1.21
 * Exceptions contain more information
+* Greatly improve performances with iterables types
 
 1.20
 * Drop support for Python 3.5.2 (3.5 series is still supported)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
-1.21
+2.0
+* Breaking API change: handlers can only be modified before the first load
 * Exceptions contain more information
 * Greatly improve performances with iterables types
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-typedload (1.21-1) UNRELEASED; urgency=medium
+typedload (2.0-1) UNRELEASED; urgency=medium
 
   * New upstream release
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from distutils.core import setup
 
 setup(
     name='typedload',
-    version='1.21',
+    version='2.0',
     description='Load and dump data from json-like format into typed data structures',
     long_description='''Load and dump json-like data into typed data structures.
 

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -267,6 +267,7 @@ class TestLoaderIndex(unittest.TestCase):
 
         loader = dataloader.Loader()
         assert loader.load(3, int) == 3
+        loader = dataloader.Loader()
         loader.handlers.pop(loader.index(int))
         with self.assertRaises(TypeError):
             loader.load(3, int)

--- a/typedload/__init__.py
+++ b/typedload/__init__.py
@@ -102,6 +102,9 @@ This can of course be used also for use cases that make sense.
 The handlers must generate exceptions from the typedload.exceptions
 module.
 
+Due to internal cache, it is not supported to modify the list of the
+handlers after the first call to dump/load.
+
 
 Name mangling
 =============

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -219,6 +219,8 @@ class Loader:
         for k, v in kwargs.items():
             setattr(self, k, v)
 
+        self._indexcache = {}
+
     def index(self, type_: Type[T]) -> int:
         """
         Returns the index in the handlers list
@@ -244,14 +246,20 @@ class Loader:
         TypeError is raised if there is no known way to treat type_,
         otherwise all errors raise a ValueError.
         """
-        try:
-            index = self.index(type_)
-        except ValueError:
-            raise TypedloadTypeError(
-                'Cannot deal with value of type %s' % type_,
-                value=value,
-                type_=type_
-            )
+        p_index = self._indexcache.get(type_)
+
+        if p_index is not None:
+            index = p_index
+        else:
+            try:
+                index = self.index(type_)
+                self._indexcache[type_] = index
+            except ValueError:
+                raise TypedloadTypeError(
+                    'Cannot deal with value of type %s' % type_,
+                    value=value,
+                    type_=type_
+                )
 
         # Add type to known types, to resolve ForwardRef later on
         if self.frefs is not None and hasattr(type_, '__name__'):

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -219,7 +219,7 @@ class Loader:
         for k, v in kwargs.items():
             setattr(self, k, v)
 
-        self._indexcache = {}
+        self._indexcache = {}  # type: Dict[Type, int]
 
     def index(self, type_: Type[T]) -> int:
         """


### PR DESCRIPTION
The function is O(n) respective to the amount of handlers present and it
needs to call a bunch of lambdas every time.

For large datasets it can make a difference to cache it so that it is
instead reduced to a dictionary look-up.

I tested it as it follows:

```python3
from random import random
from typing import *
from typedload import load

class Points(NamedTuple):
    x: float
    y: float
    z: float

EasyPoints = Tuple[float, float, float]
EasierPoints = Tuple[float, ...]

dataset = [[random(), random(), random()] for i in range(90000)]
dataset2 = [{'x':random(),'y': random(), 'z':random()} for i in range(90000)]
```

And then running

```
timeit load(dataset2, List[Points])
no cache: 2.29 s ± 65.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
   cache: 826 ms ± 23.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

timeit load(dataset, List[EasyPoints])
no cache: 2.09 s ± 366 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
   cache: 767 ms ± 14.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

timeit load(dataset, List[EasierPoints])
no cache: 1.58 s ± 32.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
   cache: 578 ms ± 16.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Of course in a list the speedup is most visible because there are the most
cache hits.

I did not test more complex and nested datasets because they are complex
to generate.

In any case it looks clear that it is worth implementing.

However some tests now fail because changing the handlers won't reset
the cache, so that needs to be solved.

Closes: #114