### PR TITLE
Build depend on python3-attr

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 typedload (1.21-1) UNRELEASED; urgency=medium
 
   * New upstream release
+  * Build depend on python3-attr.
+    Not strictly needed but this will cause the tests for the optional attr module to run as well.
 
  -- Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>  Thu, 16 Jan 2020 17:09:04 +0100
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: python
 Priority: optional
 Maintainer: Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>
 Build-Depends: debhelper (>= 12), python3, dh-python, python3-distutils,
- mypy (>= 0.740)
+ mypy (>= 0.740), python3-attr
 Standards-Version: 4.4.1
 Homepage: https://github.com/ltworf/typedload#typedload
 Vcs-Browser: https://github.com/ltworf/typedload


### PR DESCRIPTION
This will cause the tests for the optional attr module to run as well.