### PR TITLE
Improve exceptions

### DIFF
--- a/typedload/datadumper.py
+++ b/typedload/datadumper.py
@@ -3,7 +3,7 @@ typedload
 This module is the inverse of dataloader. It converts typed
 data structures to things that json can serialize.
 """
-# Copyright (C) 2018-2019 Salvo "LtWorf" Tomaselli
+# Copyright (C) 2018-2020 Salvo "LtWorf" Tomaselli
 #
 # typedload is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -125,7 +125,7 @@ class Dumper:
                 match = False
             if match:
                 return i
-        raise TypedloadValueError('Unable to dump %s' % value, value=value)
+        raise TypedloadValueError('Unable to dump %s' % value, value=value, type_=type(value))
 
     def dump(self, value: Any) -> Any:
         """

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -3,7 +3,7 @@ typedload
 Exceptions
 """
 
-# Copyright (C) 2018 Salvo "LtWorf" Tomaselli
+# Copyright (C) 2018-2020 Salvo "LtWorf" Tomaselli
 #
 # typedload is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -93,7 +93,7 @@ class TypedloadException(Exception):
 
     def __str__(self) -> str:
         def compress_value(v: Any) -> str:
-            v = str(v)
+            v = repr(v)
             if len(v) > 80:
                 return v[:77] + '...'
             return v


### PR DESCRIPTION
When dumping, the unsupported type is shown, instead of `None`.

The `repr()` rather than the `str()` of the value is pretty printed.

Dump error now:

```
typedload.exceptions.TypedloadValueError: Unable to dump /
Value: PosixPath('/')
Type: <class 'pathlib.PosixPath'>
```

Dump error before:

```
typedload.exceptions.TypedloadValueError: Unable to dump /
Value: /
Type: None
```