### PR TITLE
Do not load dict into list/tuple/set

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 2.2
 * Add Python3.9 to the supported versions
+* Prevent loading dict as List,Tuple,Set
+  This helps when using Union[Dict, List] to take the correct
+  type.
 
 2.1
 * Written new usage example

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -275,6 +275,14 @@ class TestLoaderIndex(unittest.TestCase):
 
 
 class TestExceptions(unittest.TestCase):
+    def test_dict_is_not_list(self):
+        loader = dataloader.Loader()
+        with self.assertRaises(exceptions.TypedloadTypeError):
+            loader.load({1: 1}, List[int])
+        with self.assertRaises(exceptions.TypedloadTypeError):
+            loader.load({1: 1}, Tuple[int, ...])
+        with self.assertRaises(exceptions.TypedloadTypeError):
+            loader.load({1: 1}, Set[int])
 
     def test_list_exception(self):
         loader = dataloader.Loader()

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -343,6 +343,8 @@ def _listload(l: Loader, value, type_) -> List:
     """
     This loads into something like List[int]
     """
+    if isinstance(value, dict):
+        raise TypedloadTypeError('Unable to load dictionary as a list', value=value, type_=type_)
     t = type_.__args__[0]
     try:
         return [l.load(v, t, annotation=Annotation(AnnotationType.INDEX, i)) for i, v in enumerate(value)]
@@ -371,6 +373,8 @@ def _setload(l: Loader, value, type_) -> Set:
     """
     This loads into something like Set[int]
     """
+    if isinstance(value, dict):
+        raise TypedloadTypeError('Unable to load dictionary as a set', value=value, type_=type_)
     t = type_.__args__[0]
     return {l.load(v, t, annotation=Annotation(AnnotationType.INDEX, i)) for i, v in enumerate(value)}
 
@@ -387,6 +391,8 @@ def _tupleload(l: Loader, value, type_) -> Tuple:
     """
     This loads into something like Tuple[int,str]
     """
+    if isinstance(value, dict):
+        raise TypedloadTypeError('Unable to load dictionary as a tuple', value=value, type_=type_)
     if HAS_TUPLEARGS:
         args = type_.__args__
     else:


### PR DESCRIPTION
This solves an issue when loading something into
    
    `Union[List[str], Dict[str, str]]`
    
    or loading into a NamedTuple or similar thing.
    
    Because a dict is iterable it could be loaded as a list and
    the result would be a list of the keys in the dictionary.
    
    This is not what I want so by making the load fail
    the union loader will try other options.
    
    Because Unions are not ordered the code before this commit
    will return different results randomly.