### PR TITLE
Tell users where to download packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ data = typedload.load(json.load(f), Dict[str, int])
 So when using Mypy, it makes sense to make sure that the type is correct,
 rather than hoping the data will respect the format.
 
+Download
+========
+
+* Ignore the bullshit github saying "No packages published" that is only there
+  to increase vendor lock in.
+* If you are using a debian derivative, you have `python3-typedload`
+* Latest and greatest .deb file is in https://github.com/ltworf/typedload/releases
+* It is in pypi so you can just add typedload to your requirements file.
+
 Documentation
 =============
 


### PR DESCRIPTION
Since github has this bullshit "packages" thing that seems to
duplicate the release binaries, except that nobody knows how it works
and how to use it.

I don't particularly care to spend several hours to figure it out and
to write code to use it, so I guess I will have to live with the
stupid annoying thing on the github page implying that this is a
naughty package which doesn't publish binaries.