### PR TITLE
Add handlers for types in the ipaddress stdlib module

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
 2.4
+* Support for ipaddress.IPv4Address, ipaddress.IPv6Address,
+  ipaddress.IPv4Network, ipaddress.IPv6Network,
+  ipaddress.IPv4Interface, ipaddress.IPv6Interface.
 
 2.3
 * Better type sorting in Union

--- a/tests/test_datadumper.py
+++ b/tests/test_datadumper.py
@@ -19,6 +19,7 @@
 
 import datetime
 from enum import Enum
+from ipaddress import IPv4Address, IPv4Network, IPv4Interface, IPv6Address, IPv6Network, IPv6Interface
 from pathlib import Path
 from typing import Dict, List, NamedTuple, Optional, Set, Tuple, Union
 import unittest
@@ -144,3 +145,11 @@ class TestDumpCommonTypes(unittest.TestCase):
 
     def test_path(self):
         assert dump(Path('/')) == '/'
+
+    def test_ipaddress(self):
+        assert dump(IPv4Address('10.10.10.1')) == '10.10.10.1'
+        assert dump(IPv4Network('10.10.10.0/24')) == '10.10.10.0/24'
+        assert dump(IPv4Interface('10.10.10.1/24')) == '10.10.10.1/24'
+        assert dump(IPv6Address('fe80::123')) == 'fe80::123'
+        assert dump(IPv6Network('fe80::/64')) == 'fe80::/64'
+        assert dump(IPv6Interface('fe80::123/64')) == 'fe80::123/64'

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -20,6 +20,7 @@
 import argparse
 import datetime
 from enum import Enum
+from ipaddress import IPv4Address, IPv6Address, IPv6Network, IPv4Network, IPv4Interface, IPv6Interface
 from pathlib import Path
 from typing import Dict, List, NamedTuple, Optional, Set, Tuple, Union
 import unittest
@@ -407,3 +408,34 @@ class TestCommonTypes(unittest.TestCase):
     def test_path(self):
         loader = dataloader.Loader()
         assert loader.load('/', Path) == Path('/')
+
+    def test_ipaddress(self):
+        loader = dataloader.Loader()
+        assert loader.load('10.10.10.1', IPv4Address) == IPv4Address('10.10.10.1')
+        assert loader.load('10.10.10.1', IPv4Network) == IPv4Network('10.10.10.1/32')
+        assert loader.load('10.10.10.1', IPv4Interface) == IPv4Interface('10.10.10.1/32')
+        assert loader.load('fe80::123', IPv6Address) == IPv6Address('fe80::123')
+        assert loader.load('10.10.10.0/24', IPv4Network) == IPv4Network('10.10.10.0/24')
+        assert loader.load('fe80::/64', IPv6Network) == IPv6Network('fe80::/64')
+        assert loader.load('10.10.10.1/24', IPv4Interface) == IPv4Interface('10.10.10.1/24')
+        assert loader.load('fe80::123/64', IPv6Interface) == IPv6Interface('fe80::123/64')
+
+        # Wrong IP version
+        with self.assertRaises(TypeError):
+            loader.load('10.10.10.1', IPv6Address)
+        with self.assertRaises(TypeError):
+            loader.load('fe80::123', IPv4Address)
+        with self.assertRaises(TypeError):
+            loader.load('10.10.10.0/24', IPv6Network)
+        with self.assertRaises(TypeError):
+            loader.load('fe80::123', IPv4Network)
+        with self.assertRaises(TypeError):
+            loader.load('10.10.10.1/24', IPv6Interface)
+        with self.assertRaises(TypeError):
+            loader.load('fe80::123/64', IPv4Interface)
+
+        # Wrong ipaddress type
+        with self.assertRaises(TypeError):
+            loader.load('10.10.10.1/24', IPv4Address)
+        with self.assertRaises(TypeError):
+            loader.load('10.10.10.1/24', IPv4Network)

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -421,21 +421,21 @@ class TestCommonTypes(unittest.TestCase):
         assert loader.load('fe80::123/64', IPv6Interface) == IPv6Interface('fe80::123/64')
 
         # Wrong IP version
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             loader.load('10.10.10.1', IPv6Address)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             loader.load('fe80::123', IPv4Address)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             loader.load('10.10.10.0/24', IPv6Network)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             loader.load('fe80::123', IPv4Network)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             loader.load('10.10.10.1/24', IPv6Interface)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             loader.load('fe80::123/64', IPv4Interface)
 
         # Wrong ipaddress type
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             loader.load('10.10.10.1/24', IPv4Address)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             loader.load('10.10.10.1/24', IPv4Network)

--- a/typedload/datadumper.py
+++ b/typedload/datadumper.py
@@ -206,7 +206,3 @@ def _dataclassdump(l, value):
                 del r[pyname]
                 r[dataname] = tmp
     return r
-
-
-def _ipaddressdump(l, value):
-    return str(value)

--- a/typedload/datadumper.py
+++ b/typedload/datadumper.py
@@ -21,6 +21,7 @@ data structures to things that json can serialize.
 # author Salvo "LtWorf" Tomaselli <tiposchi@tiscali.it>
 
 import datetime
+import ipaddress
 from enum import Enum
 from pathlib import Path
 from typing import *
@@ -104,6 +105,10 @@ class Dumper:
             (lambda value: isinstance(value, Dict), lambda l, value: {l.dump(k): l.dump(v) for k, v in value.items()}),
             (lambda value: isinstance(value, (datetime.date, datetime.time)), _datetimedump),
             (lambda value: isinstance(value, Path), lambda l, value: str(value)),
+            (lambda value: isinstance(value, (ipaddress.IPv4Address, ipaddress.IPv6Address,
+                                              ipaddress.IPv4Network, ipaddress.IPv6Network,
+                                              ipaddress.IPv4Interface, ipaddress.IPv6Interface)),
+             lambda l, value: str(value)),
             (is_attrs, _attrdump),
         ]  # type: List[Tuple[Callable[[Any], bool],Callable[['Dumper', Any], Any]]]
 
@@ -201,3 +206,7 @@ def _dataclassdump(l, value):
                 del r[pyname]
                 r[dataname] = tmp
     return r
+
+
+def _ipaddressdump(l, value):
+    return str(value)

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -22,6 +22,7 @@ Module to load data into typed data structures
 
 
 import datetime
+import ipaddress
 from pathlib import Path
 from typing import *
 
@@ -214,6 +215,9 @@ class Loader:
             (is_typeddict, _namedtupleload),
             (lambda type_: type_ in {datetime.date, datetime.time, datetime.datetime}, _datetimeload),
             (lambda type_: type_ == Path, _pathload),
+            (lambda type_: type_ in {ipaddress.IPv4Address, ipaddress.IPv6Address,
+                                     ipaddress.IPv4Network, ipaddress.IPv6Network,
+                                     ipaddress.IPv4Interface, ipaddress.IPv6Interface}, _ipaddressload),
             (is_attrs, _attrload),
         ]  # type: List[Tuple[Callable[[Any], bool], Callable[[Loader, Any, Type], Any]]]
 
@@ -609,4 +613,14 @@ def _pathload(l: Loader, value, type_) -> Path:
     try:
         return Path(value)
     except TypeError as e:
+        raise TypedloadTypeError(str(e), type_=type_, value=value)
+
+
+def _ipaddressload(l: Loader, value, type_):
+    """
+    Loader for all the types in the stdlib ipaddress module.
+    """
+    try:
+        return type_(value)
+    except ValueError as e:
         raise TypedloadTypeError(str(e), type_=type_, value=value)

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -22,7 +22,6 @@ Module to load data into typed data structures
 
 
 import datetime
-from enum import Enum
 from pathlib import Path
 from typing import *
 

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -623,4 +623,4 @@ def _ipaddressload(l: Loader, value, type_):
     try:
         return type_(value)
     except ValueError as e:
-        raise TypedloadTypeError(str(e), type_=type_, value=value)
+        raise TypedloadValueError(str(e), type_=type_, value=value)


### PR DESCRIPTION
I explicitly whitelisted the types in the ipaddress module rather than use an isinstance check on the common base class `_IPAddressBase`. I can change it if you prefer the isinstance approach.

See https://docs.python.org/3/library/ipaddress.html