### PR TITLE
Fix dump of attr classes when they use a factory for default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 2-5
+* Fix dump for attr classes with factory
 
 2.4
 * Support for ipaddress.IPv4Address, ipaddress.IPv6Address,

--- a/tests/test_attrload.py
+++ b/tests/test_attrload.py
@@ -72,6 +72,14 @@ class TestAttrDump(unittest.TestCase):
         dumper.hidedefault = False
         assert dumper.dump(Person()) == {'name': 'Turiddu', 'address': None}
 
+    def test_factory_dump(self):
+        @attr.s
+        class A:
+            a: List[int] = attr.ib(factory=list, metadata={'ciao': 'ciao'})
+
+        assert dump(A()) == {}
+        assert dump(A(), hidedefault=False) == {'a': []}
+
     def test_nesteddump(self):
         assert dump(
             Students('advanced coursing', [

--- a/typedload/datadumper.py
+++ b/typedload/datadumper.py
@@ -150,9 +150,13 @@ def _attrdump(d, value) -> Dict[str, Any]:
         attrval = getattr(value, attr.name)
         if not attr.repr:
             continue
-        if not (d.hidedefault and attrval == attr.default):
-            name = attr.metadata.get('name', attr.name)
-            r[name] = d.dump(attrval)
+        if d.hidedefault:
+            if attrval == attr.default:
+                continue
+            elif hasattr(attr.default, 'factory') and attrval == attr.default.factory():
+                continue
+        name = attr.metadata.get('name', attr.name)
+        r[name] = d.dump(attrval)
     return r
 
 


### PR DESCRIPTION
In case of attributes using a factory, the defaults were not
hidden correctly but considered a normal value instead.

This fixes the issue.