### PR TITLE
Introduce diversity into name mangling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
-2-5
+2.5
 * Fix dump for attr classes with factory
+* Let name mangling use arbitrary metadata fields rather than just 'name'
 
 2.4
 * Support for ipaddress.IPv4Address, ipaddress.IPv6Address,

--- a/tests/test_attrload.py
+++ b/tests/test_attrload.py
@@ -162,6 +162,16 @@ class TestMangling(unittest.TestCase):
         assert load({'b': 1, 'a': 'ciao'}, Mangle) == Mangle(1, 'ciao')
         assert dump(Mangle(1, 'ciao')) == {'b': 1, 'a': 'ciao'}
 
+    def test_weird_mangle(self):
+        @attrs
+        class Mangle:
+            a = attrib(type=int, metadata={'name': 'b', 'alt': 'q'})
+            b = attrib(type=str, metadata={'name': 'a'})
+        assert load({'b': 1, 'a': 'ciao'}, Mangle) == Mangle(1, 'ciao')
+        assert load({'q': 1, 'b': 'ciao'}, Mangle, mangle_key='alt') == Mangle(1, 'ciao')
+        assert dump(Mangle(1, 'ciao')) == {'b': 1, 'a': 'ciao'}
+        assert dump(Mangle(1, 'ciao'), mangle_key='alt') == {'q': 1, 'b': 'ciao'}
+
 
 class TestAttrExceptions(unittest.TestCase):
 

--- a/tests/test_dataclass.py
+++ b/tests/test_dataclass.py
@@ -132,3 +132,13 @@ class TestDataclassMangle(unittest.TestCase):
             b: str = field(metadata={'name': 'a'})
         assert load({'b': 1, 'a': 'ciao'}, Mangle) == Mangle(1, 'ciao')
         assert dump(Mangle(1, 'ciao')) == {'b': 1, 'a': 'ciao'}
+
+    def test_weird_mangle(self):
+        @dataclass
+        class Mangle:
+            a: int = field(metadata={'name': 'b', 'alt': 'q'})
+            b: str = field(metadata={'name': 'a'})
+        assert load({'b': 1, 'a': 'ciao'}, Mangle) == Mangle(1, 'ciao')
+        assert load({'q': 1, 'b': 'ciao'}, Mangle, mangle_key='alt') == Mangle(1, 'ciao')
+        assert dump(Mangle(1, 'ciao')) == {'b': 1, 'a': 'ciao'}
+        assert dump(Mangle(1, 'ciao'), mangle_key='alt') == {'q': 1, 'b': 'ciao'}

--- a/typedload/__init__.py
+++ b/typedload/__init__.py
@@ -147,9 +147,15 @@ The dictionary key for 'attribute' will be 'att.rib.ute:name'.
 This is very useful for keys that use invalid or reserved characters that
 can't be used in variable names.
 Another common application is to convert camelCase into not_camel_case.
+
+It is implemented this way to avoid doing automatic name translations,
+that might introduce surprises.
+
+To use a metadata key different than 'name', set the mangle_key parameter
+to the loader/dumper.
 """
 
-# Copyright (C) 2018-2019 Salvo "LtWorf" Tomaselli
+# Copyright (C) 2018-2021 Salvo "LtWorf" Tomaselli
 #
 # typedload is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -110,6 +110,10 @@ class Loader:
         handler. When disabled, the exceptions are not raised
         and the condition is considered False.
 
+    mangle_key: Defaults to 'name'
+        Specifies which key is used into the metadata dictionaries
+        to perform name-mangling.
+
     handlers: This is the list that the loader uses to
         perform its task.
         The type is:
@@ -182,6 +186,9 @@ class Loader:
 
         # Enable conversion of dict-like things to dicts, before loading
         self.dictequivalence = True
+
+        # Which key is used in metadata to perform name mangling
+        self.mangle_key = 'name'
 
         # The list of handlers to use to load the data.
         # It gets iterated in order, and the first condition
@@ -439,7 +446,7 @@ def _namedtupleload(l: Loader, value: Dict[str, Any], type_) -> Tuple:
         transforms = {}  # type: Dict[str, str]
         for pyname in fields:
             if type_.__dataclass_fields__[pyname].metadata:
-                name = type_.__dataclass_fields__[pyname].metadata.get('name')
+                name = type_.__dataclass_fields__[pyname].metadata.get(l.mangle_key)
                 if name:
                     transforms[name] = pyname
 
@@ -593,8 +600,8 @@ def _attrload(l, value, type_):
         defaults[attribute.name] = attribute.default
 
         # Manage name mangling
-        if 'name' in attribute.metadata:
-            namesmap[attribute.metadata['name']] = attribute.name
+        if l.mangle_key in attribute.metadata:
+            namesmap[attribute.metadata[l.mangle_key]] = attribute.name
 
     value = _mangle_names(namesmap, value)
 


### PR DESCRIPTION
Allow name mangling to be done using arbitrary metadata field rather than only `name`