### PR TITLE
 Simplify exceptions __str__

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,7 @@
 2.6
 * Handle Any types as passthrough
 * Easy way to handle types loaded from and dumped to str
-* Simplify how exceptions are displayed
+* Improve how exceptions are displayed
 
 2.5
 * Fix dump for attr classes with factory

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 2.6
 * Handle Any types as passthrough
 * Easy way to handle types loaded from and dumped to str
+* Simplify how exceptions are displayed
 
 2.5
 * Fix dump for attr classes with factory

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -28,6 +28,7 @@ if sys.version_info.minor > 5:
     from .test_dataloader import *
     from .test_datadumper import *
     from .test_dumpload import *
+    from .test_exceptions import *
 if sys.version_info.minor >= 7:
     from .test_dataclass import *
 if sys.version_info.minor >= 8:
@@ -35,7 +36,7 @@ if sys.version_info.minor >= 8:
     from .test_typeddict import *
 from .test_legacytuples_dataloader import *
 from .test_typechecks import *
-from .test_exceptions import *
+
 
 # Run tests for the attr plugin only if it is loaded
 try:

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -35,6 +35,7 @@ if sys.version_info.minor >= 8:
     from .test_typeddict import *
 from .test_legacytuples_dataloader import *
 from .test_typechecks import *
+from .test_exceptions import *
 
 # Run tests for the attr plugin only if it is loaded
 try:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,57 @@
+# typedload
+# Copyright (C) 2021 Salvo "LtWorf" Tomaselli
+#
+# typedload is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# author Salvo "LtWorf" Tomaselli <tiposchi@tiscali.it>
+
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, List, NamedTuple, Optional, Set, Tuple, Union
+import unittest
+
+from typedload import dataloader, load, dump, typechecks
+
+class Firewall(NamedTuple):
+    open_ports: List[int]
+
+
+class Networking(NamedTuple):
+    nic: Optional[str]
+    firewall: Firewall
+
+
+class Remote(NamedTuple):
+    networking: Networking
+
+
+class Config(NamedTuple):
+    remote: Optional[Remote]
+
+class TestExceptionsStr(unittest.TestCase):
+
+    def test_exceptions_str(self):
+        incorrect = [
+            {'remote': {'networking': {'nic': "eth0", "firewall": {"open_ports":[1,2,3, 'a']}}}},
+            {'remote': {'networking': {'nic': "eth0", "firewall": {"closed_ports": [], "open_ports":[1,2,3]}}}},
+            {'remote': {'networking': {'nic': "eth0", "firewall": {"open_ports":[2,3]}}}},
+            {'romote': {'networking': {'nic': "eth0", "firewall": {"open_ports":[2,3]}}}},
+            {'remote': {'nitworking': {'nic': "eth0", "firewall": {"open_ports":[2,3]}}}},
+        ]
+        for i in incorrect:
+            try:
+                load(i, Config, basiccast=False, failonextra=True)
+            except Exception as e:
+                str(e)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -17,9 +17,7 @@
 # author Salvo "LtWorf" Tomaselli <tiposchi@tiscali.it>
 
 
-from dataclasses import dataclass, field
-from enum import Enum
-from typing import Dict, List, NamedTuple, Optional, Set, Tuple, Union
+from typing import List, NamedTuple, Optional
 import unittest
 
 from typedload import dataloader, load, dump, typechecks

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -550,7 +550,7 @@ def _unionload(l: Loader, value, type_) -> Any:
         except Exception as e:
             exceptions.append(e)
     raise TypedloadValueError(
-        'Value could not be loaded into %s' % type_,
+        'Value of %s could not be loaded into %s' % (value_type, type_),
             value=value,
             type_=type_,
             exceptions=exceptions
@@ -583,7 +583,7 @@ def _enumload(l: Loader, value, type_) -> Enum:
         except Exception as e:
             exceptions.append(e)
     raise TypedloadValueError(
-        'Value could not be loaded into %s' % type_,
+        'Value of %s could not be loaded into %s' % (type(value), type_),
         value=value,
         type_=type_,
         exceptions=exceptions

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -348,7 +348,7 @@ def _basicload(l: Loader, value: Any, type_: type) -> Any:
             except Exception as e:
                 raise TypedloadException(str(e), value=value, type_=type_)
         else:
-            raise TypedloadValueError('Not of type %s' % type_, value=value, type_=type_)
+            raise TypedloadValueError('Got %s of type %s, expected %s' % (repr(value), type(value), type_), value=value, type_=type_)
     return value
 
 

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -84,7 +84,7 @@ class TypedloadException(Exception):
             trace: Optional[List[TraceItem]] = None,
             value: Any=None,
             type_: Optional[Type] = None,
-            exceptions: Optional[List[Exception]] = None) -> None:
+            exceptions: Optional[List[TypedloadException]] = None) -> None:
         super().__init__(description)
         self.trace = trace if trace else []
         self.value = value
@@ -135,7 +135,7 @@ class TypedloadException(Exception):
         Recursive list of all exceptions that happened in the unions
         '''
         spaces = '  ' * indent
-        msg = f'{spaces}Exceptions:\n'
+        msg = spaces + 'Exceptions:\n'
         for i in self.exceptions:
             msg += self._firstlines(indent + 1) + '\n'
             if i.exceptions:
@@ -147,7 +147,7 @@ class TypedloadException(Exception):
         Returns error string and the path
         '''
         spaces = '  ' * indent
-        return f'\n'.join(f'{spaces}{i}' for i in self.args) + f'\n{spaces}Path: ' + self.path
+        return '\n'.join(spaces + str(i) for i in self.args) + '\n' + spaces + 'Path: ' + self.path
 
     def __str__(self) -> str:
         msg = self._firstlines(0)

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -137,10 +137,10 @@ class TypedloadException(Exception):
         spaces = '  ' * indent
         msg = spaces + 'Exceptions:\n'
         for i in self.exceptions:
-            msg += self._firstlines(indent + 1) + '\n'
+            msg += i._firstlines(indent + 1) + '\n'
             if i.exceptions:
                 msg += i._subexceptions(indent + 1)
-        return msg.rstrip()
+        return msg
 
     def _firstlines(self, indent: int) -> str:
         '''
@@ -152,7 +152,7 @@ class TypedloadException(Exception):
     def __str__(self) -> str:
         msg = self._firstlines(0)
         if self.exceptions:
-            msg += '\n' + self._subexceptions(0)
+            msg += '\n' + self._subexceptions(0).rstrip()
         return msg
 
 

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -114,7 +114,7 @@ class TypedloadException(Exception):
         msg = spaces + 'Exceptions:\n'
         for i in self.exceptions:
             msg += i._firstline(indent + 1) + '\n'
-            msg += spaces + '  ' 'Path: ' + self._path(trace) + '\n'
+            msg += spaces + '  ' 'Path: ' + self._path(self.trace + i.trace[1:]) + '\n'
             if i.exceptions:
                 msg += i._subexceptions(indent + 1, self.trace + i.trace[1:])
         return msg

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -92,7 +92,7 @@ class TypedloadException(Exception):
         self.exceptions = exceptions if exceptions else []
 
     @staticmethod
-    def _path(trace) -> str:
+    def _path(trace: List[TraceItem]) -> str:
         '''
         Compact representation of where in the data the exception happened
         '''

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -3,7 +3,7 @@ typedload
 Exceptions
 """
 
-# Copyright (C) 2018-2020 Salvo "LtWorf" Tomaselli
+# Copyright (C) 2018-2021 Salvo "LtWorf" Tomaselli
 #
 # typedload is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -130,8 +130,30 @@ class TypedloadException(Exception):
             e += 'Value: %s\n' % compress_value(i.value)
         return e
 
+    def _subexceptions(self, indent: int) -> str:
+        '''
+        Recursive list of all exceptions that happened in the unions
+        '''
+        spaces = '  ' * indent
+        msg = f'{spaces}Exceptions:\n'
+        for i in self.exceptions:
+            msg += self._firstlines(indent + 1) + '\n'
+            if i.exceptions:
+                msg += i._subexceptions(indent + 1)
+        return msg.rstrip()
+
+    def _firstlines(self, indent: int) -> str:
+        '''
+        Returns error string and the path
+        '''
+        spaces = '  ' * indent
+        return f'\n'.join(f'{spaces}{i}' for i in self.args) + f'\n{spaces}Path: ' + self.path
+
     def __str__(self) -> str:
-        return '\n'.join(self.args) + '\nPath: ' + self.path
+        msg = self._firstlines(0)
+        if self.exceptions:
+            msg += '\n' + self._subexceptions(0)
+        return msg
 
 
 class TypedloadValueError(TypedloadException, ValueError):

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -106,30 +106,6 @@ class TypedloadException(Exception):
             path[0] = ''
         return '.'.join(path)
 
-    @property
-    def strtrace(self):
-        '''
-        Returns a string representation of the stacktrace where the exception happened.
-        '''
-        def compress_value(v: Any) -> str:
-            v = repr(v)
-            if len(v) > 30:
-                return v[:27] + '...'
-            return v
-        e = '%s\nValue: %s\nType: %s\n' % (
-            super().__str__(),
-            compress_value(self.value),
-            self.type_
-        )
-        if self.trace:
-            e += '\nLoad trace:\n'
-        for i in self.trace[-2:]:
-            e += 'Type: %s ' % i.type_
-            if i.annotation:
-                e += 'Annotation: (%s %s) ' % (i.annotation[0], i.annotation[1])
-            e += 'Value: %s\n' % compress_value(i.value)
-        return e
-
     def _subexceptions(self, indent: int) -> str:
         '''
         Recursive list of all exceptions that happened in the unions

--- a/typedload/exceptions.py
+++ b/typedload/exceptions.py
@@ -84,7 +84,7 @@ class TypedloadException(Exception):
             trace: Optional[List[TraceItem]] = None,
             value: Any=None,
             type_: Optional[Type] = None,
-            exceptions: Optional[List[TypedloadException]] = None) -> None:
+            exceptions: Optional[List['TypedloadException']] = None) -> None:
         super().__init__(description)
         self.trace = trace if trace else []
         self.value = value


### PR DESCRIPTION
Do not print the trace of all the handlers, just print the path of where in the data the error happened.
    
The trace data is still available, if it is needed and the old printed thing is still accessible under strtrace().

### Before:
    
```
TypedloadValueError: invalid literal for int() with base 10: 'error'
Value: 'error'
Type: <class 'int'>

Load trace:
Type: <class '__main__.Config'> Value: {'network': {'connections': [{'addr': '10.1', 'port': 41}, {'addr': '10.14', ...
Type: <class '__main__.Network'> Annotation: (AnnotationType.FIELD network) Value: {'connections': [{'addr': '10.1', 'port': 41}, {'addr': '10.14', 'port': 'err...
Type: typing.List[__main__.Connection] Annotation: (AnnotationType.FIELD connections) Value: [{'addr': '10.1', 'port': 41}, {'addr': '10.14', 'port': 'error'}]
Type: <class '__main__.Connection'> Annotation: (AnnotationType.INDEX 1) Value: {'addr': '10.14', 'port': 'error'}
Type: <class 'int'> Annotation: (AnnotationType.FIELD port) Value: 'error'
Path: .network.connections.[1].port
```

### After:
    
```
TypedloadValueError: invalid literal for int() with base 10: 'error'
Path: .network.connections.[1].port
```