### PR TITLE
Add strconstructed dictionary for simple type/string conversions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 2.6
 * Handle Any types as passthrough
+* Easy way to handle types loaded from and dumped to str
 
 2.5
 * Fix dump for attr classes with factory

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -162,6 +162,41 @@ character = typedload.load(data, Character)
 typedload.dump(character, mangle_key='alt_name')
 ```
 
+Load and dump types from str
+----------------------------
+
+Some classes are easy to load and dump from `str`. For example this is done for `Path`.
+
+Let's assume we want to have a class that is called `SerialNumber` that we load from a string and dump back to a string.
+
+Here's how it can be done:
+
+```python
+from typing import List
+import typedload.datadumper
+import typedload.dataloader
+
+class SerialNumber:
+    def __init__(self, sn: str) -> None:
+        # Some validation
+        if ' ' in sn:
+            raise Exception('Invalid serial number')
+
+        self.sn = sn
+
+    def __str__(self):
+        return self.sn
+
+l = typedload.dataloader.Loader()
+d = typedload.datadumper.Dumper()
+l.strconstructed.add(SerialNumber)
+d.strconstructed.add(SerialNumber)
+
+serials = l.load(['1', '2', '3'], List[SerialNumber])
+d.dump(serials)
+```
+
+
 Custom handlers
 ---------------
 

--- a/docs/supported_types.md
+++ b/docs/supported_types.md
@@ -295,9 +295,18 @@ This will just return `obj` without doing any check or transformation.
 
 To work with `dump()`, `obj` needs to be of a supported type, or an handler is needed.
 
+String constructed
+------------------
 
-pathlib.Path
-------------
+Loaders and dumpers have a set of `strconstructed`.
+
+Those are types that accept a single `str` parameter in their constructor and have a `__str__` method that returns that parameter.
+
+For those types, a specific handler is not needed and they can just be added to the `strconstructed` set.
+
+The preset ones are:
+
+### pathlib.Path
 
 ```python
 In : typedload.load('/tmp/', Path)
@@ -309,8 +318,7 @@ Out: PosixPath('/tmp/file.txt')
 
 Loads a string as a `Path`; when dumping it goes back to being a string.
 
-ipaddress.IPv*Address/Network/Interface
----------------------------------------
+### ipaddress.IPv*Address/Network/Interface
 
 * ipaddress.IPv4Address
 * ipaddress.IPv6Address

--- a/tests/test_datadumper.py
+++ b/tests/test_datadumper.py
@@ -1,5 +1,5 @@
 # typedload
-# Copyright (C) 2018-2020 Salvo "LtWorf" Tomaselli
+# Copyright (C) 2018-2021 Salvo "LtWorf" Tomaselli
 #
 # typedload is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -50,6 +50,18 @@ class TestLegacyDump(unittest.TestCase):
     def test_dump(self):
         A = NamedTuple('A',[('a', int), ('b', str)])
         assert dump(A(1, '12')) == {'a': 1, 'b': '12'}
+
+
+class TestStrconstructed(unittest.TestCase):
+
+    def test_dump_strconstructed(self):
+        dumper = datadumper.Dumper()
+        class Q:
+            def __str__(self):
+                return '42'
+
+        dumper.strconstructed.add(Q)
+        assert dumper.dump(Q()) == '42'
 
 
 class TestBasicDump(unittest.TestCase):

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -81,6 +81,19 @@ class TestRealCase(unittest.TestCase):
         loader.load(c, BoardItem)
 
 
+class TestStrconstructed(unittest.TestCase):
+
+    def test_load_strconstructed(self):
+        loader = dataloader.Loader()
+        class Q:
+            def __init__(self, p):
+                self.param = p
+
+        loader.strconstructed.add(Q)
+        data = loader.load('42', Q)
+        assert data.param == '42'
+
+
 class TestUnion(unittest.TestCase):
     def test_json(self):
         '''


### PR DESCRIPTION
This way a single handler is used for a multitude of types, without
the need of creating a new handler every time that such a small type
is added.