### PR TITLE
failonextra triggers a failure if fields are dropped in mangling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 2.7
+* failonextra triggers failure when dropping fields in mangling
 
 2.6
 * Handle Any types as passthrough

--- a/tests/test_attrload.py
+++ b/tests/test_attrload.py
@@ -145,6 +145,14 @@ class TestAttrload(unittest.TestCase):
 
 class TestMangling(unittest.TestCase):
 
+    def test_mangle_extra(self):
+        @attrs
+        class Mangle:
+            value: int = attrib(metadata={'name': 'Value'})
+        assert load({'value': 12, 'Value': 12}, Mangle) == Mangle(12)
+        with self.assertRaises(exceptions.TypedloadValueError):
+            load({'value': 12, 'Value': 12}, Mangle, failonextra=True)
+
     def test_load_metanames(self):
         a = {'va.lue': 12}
         b = a.copy()

--- a/tests/test_attrload.py
+++ b/tests/test_attrload.py
@@ -148,7 +148,7 @@ class TestMangling(unittest.TestCase):
     def test_mangle_extra(self):
         @attrs
         class Mangle:
-            value: int = attrib(metadata={'name': 'Value'})
+            value = attrib(metadata={'name': 'Value'}, type=int)
         assert load({'value': 12, 'Value': 12}, Mangle) == Mangle(12)
         with self.assertRaises(exceptions.TypedloadValueError):
             load({'value': 12, 'Value': 12}, Mangle, failonextra=True)

--- a/tests/test_dataclass.py
+++ b/tests/test_dataclass.py
@@ -22,7 +22,7 @@ from enum import Enum
 from typing import Dict, List, NamedTuple, Optional, Set, Tuple, Union
 import unittest
 
-from typedload import dataloader, load, dump, typechecks
+from typedload import dataloader, load, dump, typechecks, exceptions
 
 
 class TestDataclassLoad(unittest.TestCase):
@@ -117,6 +117,14 @@ class TestDataclassDump(unittest.TestCase):
 
 
 class TestDataclassMangle(unittest.TestCase):
+
+    def test_mangle_extra(self):
+        @dataclass
+        class Mangle:
+            value: int = field(metadata={'name': 'Value'})
+        assert load({'value': 12, 'Value': 12}, Mangle) == Mangle(12)
+        with self.assertRaises(exceptions.TypedloadValueError):
+            load({'value': 12, 'Value': 12}, Mangle, failonextra=True)
 
     def test_mangle_load(self):
         @dataclass


### PR DESCRIPTION
In name mangling now fields which use the python name instead of the 
mangled name get dropped and not passed forward.

This means that what used to work, passing the python unmangled name
in the dictionary, no longer works.

However, the field was dropped silently. This patch makes the drop
raise an exception if failonextra is True.