### PR TITLE
List possible enum values in exception

### DIFF
--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -600,8 +600,13 @@ def _enumload(l: Loader, value, type_) -> Enum:
             return type_(l.load(value, t, annotation=Annotation(AnnotationType.UNION, t)))
         except Exception as e:
             exceptions.append(e)
+    if len(type_.__members__) <= 10 and all(type(i.value) in l.basictypes for i in type_.__members__.values()):
+        lst = '\nValue %s not between: ' % repr(value) + \
+        ', '.join(repr(i.value) for i in type_.__members__.values())
+    else:
+        lst = ''
     raise TypedloadValueError(
-        'Value of %s could not be loaded into %s' % (tname(type(value)), tname(type_)),
+        'Value of %s could not be loaded into %s%s' % (tname(type(value)), tname(type_), lst),
         value=value,
         type_=type_,
         exceptions=exceptions


### PR DESCRIPTION
If the enum contains 10 or less values, all belonging to basictypes, then if
the load fails, the loaded value plus a list of the accepted values is added
as a string to the exception.
    
The limitation on size and type is because I want to limit the noise.
    
Fixes: #195