### PR TITLE
Python3.10 will not have late type evaluation

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -13,6 +13,6 @@ jobs:
       with:
         python-version: '3.x'
     - name: Install dependencies
-      run: pip install mypy
+      run: pip install mypy types-dataclasses
     - name: mypy
       run: make mypy

--- a/.github/workflows/test_matrix.yml
+++ b/.github/workflows/test_matrix.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10.0-alpha.4']
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10.0-alpha.7']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test_matrix.yml
+++ b/.github/workflows/test_matrix.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10.0-alpha.7']
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10.0-beta.3']
 
     steps:
     - uses: actions/checkout@v2

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,3 @@
-typedload (3.0-1) UNRELEASED; urgency=medium
-
-  * New upstream release
-
- -- Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>  Tue, 06 Apr 2021 21:43:18 +0200
-
 typedload (2.7-1) unstable; urgency=low
 
   * New upstream release

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+typedload (2.8-1) UNRELEASED; urgency=medium
+
+  * New upstream release
+
+ -- Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>  Thu, 22 Apr 2021 11:22:47 +0200
+
 typedload (2.7-1) unstable; urgency=low
 
   * New upstream release

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,4 @@
-3.0
-* Support PEP 563: Postponed Evaluation of Annotations
-  This means breaking changes on how the python typing works,
-  so for this a new major version is used.
+2.8
 * Better report errors for Enum
 * Improve support for inheritance with mixed totality of TypedDict (requires Python 3.9)
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ like json, because it guarantees that the data will have the expected format.
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     keywords='typing types mypy json',
     packages=['typedload'],

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from distutils.core import setup
 
 setup(
     name='typedload',
-    version='3.0',
+    version='2.7',
     description='Load and dump data from json-like format into typed data structures',
     long_description='''Load and dump json-like data into typed data structures.
 
@@ -48,7 +48,6 @@ like json, because it guarantees that the data will have the expected format.
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
     ],
     keywords='typing types mypy json',
     packages=['typedload'],

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from distutils.core import setup
 
 setup(
     name='typedload',
-    version='2.7',
+    version='2.8',
     description='Load and dump data from json-like format into typed data structures',
     long_description='''Load and dump json-like data into typed data structures.
 

--- a/tests/test_dataclass.py
+++ b/tests/test_dataclass.py
@@ -37,21 +37,6 @@ class NestedLoadB:
     b: List[NestedLoadA]
 
 
-@dataclass
-class UnionA:
-    a: int
-
-
-@dataclass
-class UnionB:
-    a: str
-
-
-@dataclass
-class UnionC:
-    val: Union[UnionA, UnionB]
-
-
 class TestDataclassLoad(unittest.TestCase):
 
     def test_do_not_init(self):
@@ -116,11 +101,20 @@ class TestDataclassLoad(unittest.TestCase):
 
 class TestDataclassUnion(unittest.TestCase):
 
-    def test_nested_union(self):
+    def test_ComplicatedUnion(self):
+        @dataclass
+        class A:
+            a: int
+        @dataclass
+        class B:
+            a: str
+        @dataclass
+        class C:
+            val: Union[A, B]
         loader = dataloader.Loader()
         loader.basiccast = False
-        assert type(loader.load({'val': {'a': 1}}, UnionC).val) == UnionA
-        assert type(loader.load({'val': {'a': '1'}}, UnionC).val) == UnionB
+        assert type(loader.load({'val': {'a': 1}}, C).val) == A
+        assert type(loader.load({'val': {'a': '1'}}, C).val) == B
 
 class TestDataclassDump(unittest.TestCase):
 

--- a/tests/test_dataclass.py
+++ b/tests/test_dataclass.py
@@ -25,18 +25,6 @@ import unittest
 from typedload import dataloader, load, dump, typechecks, exceptions
 
 
-@dataclass
-class NestedLoadA:
-    a: int
-    b: str
-
-
-@dataclass
-class NestedLoadB:
-    a: NestedLoadA
-    b: List[NestedLoadA]
-
-
 class TestDataclassLoad(unittest.TestCase):
 
     def test_do_not_init(self):
@@ -84,11 +72,20 @@ class TestDataclassLoad(unittest.TestCase):
         assert load({'a': 101, 'b': 'ciao'}, A) == A(101, 'ciao')
 
     def test_nestedload(self):
-        assert load({'a': {'a': 101, 'b': 'ciao'}, 'b': []}, NestedLoadB) == NestedLoadB(NestedLoadA(101, 'ciao'), [])
+        @dataclass
+        class A:
+            a: int
+            b: str
+        @dataclass
+        class B:
+            a: A
+            b: List[A]
+
+        assert load({'a': {'a': 101, 'b': 'ciao'}, 'b': []}, B) == B(A(101, 'ciao'), [])
         assert load(
             {'a': {'a': 101, 'b': 'ciao'}, 'b': [{'a': 1, 'b': 'a'},{'a': 0, 'b': 'b'}]},
-            NestedLoadB
-        ) == NestedLoadB(NestedLoadA(101, 'ciao'), [NestedLoadA(1, 'a'),NestedLoadA(0, 'b')])
+            B
+        ) == B(A(101, 'ciao'), [A(1, 'a'),A(0, 'b')])
 
     def test_defaultvalue(self):
         @dataclass

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -28,18 +28,6 @@ import unittest
 from typedload import dataloader, load, exceptions
 
 
-class UnionA(NamedTuple):
-    a: int
-
-
-class UnionB(NamedTuple):
-    a: str
-
-
-class UnionC(NamedTuple):
-    val: Union[UnionA, UnionB]
-
-
 class SelfRef(NamedTuple):
     value: int = 1
     next: Optional['SelfRef'] = None
@@ -159,11 +147,20 @@ class TestUnion(unittest.TestCase):
             assert loader.load({'a': 12}, t) == expected
 
 
-    def test_complicated_union(self):
+    def test_ComplicatedUnion(self):
+        class A(NamedTuple):
+            a: int
+
+        class B(NamedTuple):
+            a: str
+
+        class C(NamedTuple):
+            val: Union[A, B]
+
         loader = dataloader.Loader()
         loader.basiccast = False
-        assert type(loader.load({'val': {'a': 1}}, UnionC).val) == UnionA
-        assert type(loader.load({'val': {'a': '1'}}, UnionC).val) == UnionB
+        assert type(loader.load({'val': {'a': 1}}, C).val) == A
+        assert type(loader.load({'val': {'a': '1'}}, C).val) == B
 
     def test_optional(self):
         loader = dataloader.Loader()

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -281,6 +281,16 @@ class TestForwardRef(unittest.TestCase):
         with self.assertRaises(Exception):
             loader.load(3, A)
 
+    def test_add_fref(self):
+        class A(NamedTuple):
+            i: 'alfio'
+        loader = dataloader.Loader()
+        with self.assertRaises(ValueError):
+            loader.load({'i': 3}, A)
+        loader.frefs['alfio'] = int
+        assert loader.load({'i': 3}, A) == A(3)
+
+
 
 class TestLoaderIndex(unittest.TestCase):
 

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -28,11 +28,6 @@ import unittest
 from typedload import dataloader, load, exceptions
 
 
-class SelfRef(NamedTuple):
-    value: int = 1
-    next: Optional['SelfRef'] = None
-
-
 class TestRealCase(unittest.TestCase):
 
     def test_stopboard(self):
@@ -272,10 +267,12 @@ class TestEnum(unittest.TestCase):
 class TestForwardRef(unittest.TestCase):
 
     def test_known_refs(self):
-
-        l = {'next': {'value': 12}, 'value': 12}
+        class Node(NamedTuple):
+            value: int = 1
+            next: Optional['Node'] = None
+        l = {'next': {}, 'value': 12}
         loader = dataloader.Loader()
-        assert loader.load(l, SelfRef) == SelfRef(value=12,next=SelfRef(value=12, next=None))
+        assert loader.load(l, Node) == Node(value=12,next=Node())
 
     def test_disable(self):
         class A(NamedTuple):

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -42,14 +42,6 @@ class ExceptionsB(NamedTuple):
     b: int
 
 
-class NestedA(NamedTuple):
-    a: int
-
-
-class NestedB(NamedTuple):
-    a: NestedA
-
-
 class TestRealCase(unittest.TestCase):
 
     def test_stopboard(self):
@@ -237,11 +229,16 @@ class TestNamedTuple(unittest.TestCase):
         assert loader.load({}, A) == r
 
     def test_nested(self):
+        class A(NamedTuple):
+            a: int
+
+        class B(NamedTuple):
+            a: A
         loader = dataloader.Loader()
-        r = NestedB(NestedA(1))
-        assert loader.load({'a': {'a': 1}}, NestedB) == r
+        r = B(A(1))
+        assert loader.load({'a': {'a': 1}}, B) == r
         with self.assertRaises(TypeError):
-            loader.load({'a': {'a': 1}}, NestedA)
+            loader.load({'a': {'a': 1}}, A)
 
     def test_fail(self):
         class A(NamedTuple):

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -62,36 +62,36 @@ class NestedB(NamedTuple):
     a: NestedA
 
 
-class VehicleType(Enum):
-    ST = 'ST'
-    TRAM = 'TRAM'
-    BUS = 'BUS'
-    WALK = 'WALK'
-    BOAT = 'BOAT'
-
-class BoardItem(NamedTuple):
-    name: str
-    type: VehicleType
-    date: str
-    time: str
-    stop: str
-    stopid: str
-    journeyid: str
-    sname: Optional[str] = None
-    track: str = ''
-    rtDate: Optional[str] = None
-    rtTime: Optional[str] = None
-    direction: Optional[str] = None
-    accessibility: str = ''
-    bgColor: str = '#0000ff'
-    fgColor: str = '#ffffff'
-    stroke: Optional[str] = None
-    night: bool = False
-
-
 class TestRealCase(unittest.TestCase):
 
     def test_stopboard(self):
+
+        class VehicleType(Enum):
+            ST = 'ST'
+            TRAM = 'TRAM'
+            BUS = 'BUS'
+            WALK = 'WALK'
+            BOAT = 'BOAT'
+
+        class BoardItem(NamedTuple):
+            name: str
+            type: VehicleType
+            date: str
+            time: str
+            stop: str
+            stopid: str
+            journeyid: str
+            sname: Optional[str] = None
+            track: str = ''
+            rtDate: Optional[str] = None
+            rtTime: Optional[str] = None
+            direction: Optional[str] = None
+            accessibility: str = ''
+            bgColor: str = '#0000ff'
+            fgColor: str = '#ffffff'
+            stroke: Optional[str] = None
+            night: bool = False
+
         c = {
             'JourneyDetailRef': {'ref': 'https://api.vasttrafik.se/bin/rest.exe/v2/journeyDetail?ref=859464%2F301885%2F523070%2F24954%2F80%3Fdate%3D2018-04-08%26station_evaId%3D5862002%26station_type%3Ddep%26format%3Djson%26'},
             'accessibility': 'wheelChair',

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -33,15 +33,6 @@ class SelfRef(NamedTuple):
     next: Optional['SelfRef'] = None
 
 
-class ExceptionsA(NamedTuple):
-    a: int
-
-
-class ExceptionsB(NamedTuple):
-    a: ExceptionsA
-    b: int
-
-
 class TestRealCase(unittest.TestCase):
 
     def test_stopboard(self):
@@ -344,20 +335,25 @@ class TestExceptions(unittest.TestCase):
             assert e.trace[-1].annotation[1] == 'q'
 
     def test_attrname(self):
+        class A(NamedTuple):
+            a: int
+        class B(NamedTuple):
+            a: A
+            b: int
         loader = dataloader.Loader()
 
         try:
-            loader.load({'a': 'q'}, ExceptionsA)
+            loader.load({'a': 'q'}, A)
         except Exception as e:
             assert e.trace[-1].annotation[1] == 'a'
 
         try:
-            loader.load({'a':'q','b': {'a': 1}}, ExceptionsB)
+            loader.load({'a':'q','b': {'a': 1}}, B)
         except Exception as e:
             assert e.trace[-1].annotation[1] == 'a'
 
         try:
-            loader.load({'a':3,'b': {'a': 'q'}}, ExceptionsB)
+            loader.load({'a':3,'b': {'a': 'q'}}, B)
         except Exception as e:
             assert e.trace[-1].annotation[1] == 'a'
 

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -461,17 +461,19 @@ def _namedtupleload(l: Loader, value: Dict[str, Any], type_) -> Any:
     """
     This loads a Dict[str, Any] into a NamedTuple.
     """
-    type_hints = get_type_hints(type_)
-    fields = set(type_hints.keys())
     if not hasattr(type_, '__dataclass_fields__'):
+        fields = set(type_.__annotations__.keys())
         optional_fields = set(getattr(type_, '_field_defaults', {}).keys())
+        type_hints = type_.__annotations__
     else:
         #dataclass
         import dataclasses
+        fields = set(type_.__dataclass_fields__.keys())
         optional_fields = {k for k,v in type_.__dataclass_fields__.items() if
                            v.init == False or
                            not isinstance(v.default, dataclasses._MISSING_TYPE) or
                            not isinstance(v.default_factory, dataclasses._MISSING_TYPE)}
+        type_hints = {k: v.type for k,v in type_.__dataclass_fields__.items()}
 
         #Name mangling
 


### PR DESCRIPTION
This means that the breaking API changes were useless, so I can
revert all of them, keep things as before, and prepare for a minor
version bump instead.

https://mail.python.org/archives/list/python-dev@python.org/thread/CLVXXPQ2T2LQ5MP2Y53VVQFCXYWQJHKZ/


Fixes #199 