### PR TITLE
Add support for TypedDict with multiple totality

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
   This means breaking changes on how the python typing works,
   so for this a new major version is used.
 * Better report errors for Enum
+* Improve support for inheritance with mixed totality of TypedDict
 
 2.7
 * failonextra triggers failure when dropping fields in mangling

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
   This means breaking changes on how the python typing works,
   so for this a new major version is used.
 * Better report errors for Enum
-* Improve support for inheritance with mixed totality of TypedDict
+* Improve support for inheritance with mixed totality of TypedDict (requires Python 3.9)
 
 2.7
 * failonextra triggers failure when dropping fields in mangling

--- a/tests/test_typeddict.py
+++ b/tests/test_typeddict.py
@@ -35,7 +35,22 @@ class A(TypedDict):
 class B(TypedDict, total=False):
     val: str
 
+class C(A, total=False):
+    vel: int
+
 class TestTypeddictLoad(unittest.TestCase):
+
+    def test_mixed_totality(self):
+        with self.assertRaises(ValueError):
+            load({}, C)
+        assert load({'val': 'a'}, C) == {'val': 'a'}
+        with self.assertRaises(ValueError):
+            load({'val': 'a', 'vel': 'q'}, C)
+        assert load({'val': 'a', 'vel': 1}, C) == {'val': 'a', 'vel': 1}
+        assert load({'val': 'a', 'vel': '1'}, C) == {'val': 'a', 'vel': 1}
+        assert load({'val': 'a','vil': 2}, C) == {'val': 'a'}
+        with self.assertRaises(ValueError):
+            load({'val': 'a','vil': 2}, C, failonextra=True)
 
     def test_totality(self):
         with self.assertRaises(ValueError):

--- a/tests/test_typeddict.py
+++ b/tests/test_typeddict.py
@@ -19,6 +19,7 @@
 
 from typing import TypedDict
 import unittest
+import sys
 
 from typedload import dataloader, load, dump, typechecks
 
@@ -41,6 +42,11 @@ class C(A, total=False):
 class TestTypeddictLoad(unittest.TestCase):
 
     def test_mixed_totality(self):
+
+        if sys.version_info.minor == 8:
+            # This only works from 3.9
+            return
+
         with self.assertRaises(ValueError):
             load({}, C)
         assert load({'val': 'a'}, C) == {'val': 'a'}

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -488,10 +488,10 @@ def _namedtupleload(l: Loader, value: Dict[str, Any], type_) -> Any:
         except ValueError as e:
             raise TypedloadValueError(str(e), value=value, type_=type_)
 
-    if getattr(type_, '__total__', True) == False:
-        # For TypedDict, total=False means that fields can be safely skipped
-        # So we set the necessary_fields to empty.
-        necessary_fields = set()
+    if hasattr(type_, '__required_keys__') and hasattr(type_, '__optional_keys__'):
+        # TypedDict
+        necessary_fields = type_.__required_keys__
+        optional_fields = type_.__optional_keys__
     else:
         necessary_fields = fields.difference(optional_fields)
 

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -489,9 +489,12 @@ def _namedtupleload(l: Loader, value: Dict[str, Any], type_) -> Any:
             raise TypedloadValueError(str(e), value=value, type_=type_)
 
     if hasattr(type_, '__required_keys__') and hasattr(type_, '__optional_keys__'):
-        # TypedDict
+        # TypedDict, since 3.9
         necessary_fields = type_.__required_keys__
         optional_fields = type_.__optional_keys__
+    elif getattr(type_, '__total__', True) == False:
+        # TypedDict, only for 3.8
+        necessary_fields = set()
     else:
         necessary_fields = fields.difference(optional_fields)
 


### PR DESCRIPTION
Fixes: #204

Basically TypedDict by default assumes all defined fields must be
present in the dictionary.

When created with `total=False` instead it makes all fields not
required.

To obtain a TypedDict which has some required fields and some that
are not, one must subclass a TypedDict and set a different total.

Conveniently it turns out that python exports what fields are needed
so that it's just a matter of copying those values.

This only works from 3.9