### PR TITLE
Remove useless call to cast()

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 2.9
 * Use README on pypi.org
+* Tiny speed improvement
 
 2.8
 * Better report errors for Enum

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -293,7 +293,7 @@ class Loader:
                 value = {k: v for k,v in value._get_kwargs()}
 
         try:
-            return cast(T, func(self, value, type_))
+            return func(self, value, type_)
         except Exception as e:
             assert isinstance(e, TypedloadException)
             e.trace.insert(0, TraceItem(value, type_, annotation))


### PR DESCRIPTION
Profiler showed it was called a lot and it wasn't a no-op as I had presumed.