### PR TITLE
Separate handlers for the various object loaders.

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -13,6 +13,6 @@ jobs:
       with:
         python-version: '3.x'
     - name: Install dependencies
-      run: pip install mypy types-dataclasses
+      run: pip install mypy types-dataclasses attrs
     - name: mypy
       run: make mypy

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 2.13
 ====
+* Separate and simpler handlers for NamedTuple, dataclass, attrs, TypedDict
 
 2.12
 ====

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -230,10 +230,10 @@ class Loader:
             (is_set, _setload),
             (is_frozenset, _frozensetload),
             (is_namedtuple, _namedtupleload),
-            (is_dataclass, _namedtupleload),
+            (is_dataclass, _dataclassload),
             (is_forwardref, _forwardrefload),
             (is_literal, _literalload),
-            (is_typeddict, _namedtupleload),
+            (is_typeddict, _typeddictload),
             (lambda type_: type_ in {datetime.date, datetime.time, datetime.datetime}, _datetimeload),
             (lambda type_: type_ in self.strconstructed, _strconstructload),
             (is_attrs, _attrload),
@@ -469,49 +469,42 @@ def _mangle_names(namesmap: Dict[str, str], value: Dict[str, Any], failonextra: 
     return r
 
 
-def _namedtupleload(l: Loader, value: Dict[str, Any], type_) -> Any:
+def _dataclassload(l: Loader, value: Dict[str, Any], type_) -> Any:
     """
     This loads a Dict[str, Any] into a NamedTuple.
     """
-    if not hasattr(type_, '__dataclass_fields__'):
-        fields = set(type_.__annotations__.keys())
-        optional_fields = set(getattr(type_, '_field_defaults', {}).keys())
-        type_hints = type_.__annotations__
-    else:
-        #dataclass
-        from dataclasses import _MISSING_TYPE as DT_MISSING_TYPE
-        fields = set(type_.__dataclass_fields__.keys())
-        optional_fields = {k for k,v in type_.__dataclass_fields__.items() if
-                           v.init == False or
-                           not isinstance(v.default, DT_MISSING_TYPE) or
-                           not isinstance(v.default_factory, DT_MISSING_TYPE)}
-        type_hints = {k: v.type for k,v in type_.__dataclass_fields__.items()}
+        #fields = set(type_.__annotations__.keys())
+        #optional_fields = set(getattr(type_, '_field_defaults', {}).keys())
+        #type_hints = type_.__annotations__
+        #necessary_fields
+    from dataclasses import _MISSING_TYPE as DT_MISSING_TYPE
+    fields = set(type_.__dataclass_fields__.keys())
+    optional_fields = {k for k,v in type_.__dataclass_fields__.items() if
+                        v.init == False or
+                        not isinstance(v.default, DT_MISSING_TYPE) or
+                        not isinstance(v.default_factory, DT_MISSING_TYPE)}
+    type_hints = {k: v.type for k,v in type_.__dataclass_fields__.items()}
 
-        #Name mangling
+    #Name mangling
 
-        # Prepare the list of the needed name changes
-        transforms = {}  # type: Dict[str, str]
-        for pyname in fields:
-            if type_.__dataclass_fields__[pyname].metadata:
-                name = type_.__dataclass_fields__[pyname].metadata.get(l.mangle_key)
-                if name:
-                    transforms[name] = pyname
+    # Prepare the list of the needed name changes
+    transforms = {}  # type: Dict[str, str]
+    for pyname in fields:
+        if type_.__dataclass_fields__[pyname].metadata:
+            name = type_.__dataclass_fields__[pyname].metadata.get(l.mangle_key)
+            if name:
+                transforms[name] = pyname
 
-        try:
-            value = _mangle_names(transforms, value, l.failonextra)
-        except ValueError as e:
-            raise TypedloadValueError(str(e), value=value, type_=type_)
+    try:
+        value = _mangle_names(transforms, value, l.failonextra)
+    except ValueError as e:
+        raise TypedloadValueError(str(e), value=value, type_=type_)
 
-    if hasattr(type_, '__required_keys__') and hasattr(type_, '__optional_keys__'):
-        # TypedDict, since 3.9
-        necessary_fields = type_.__required_keys__
-        optional_fields = type_.__optional_keys__
-    elif getattr(type_, '__total__', True) == False:
-        # TypedDict, only for 3.8
-        necessary_fields = set()
-    else:
-        necessary_fields = fields.difference(optional_fields)
+    necessary_fields = fields.difference(optional_fields)
+    return _objloader(l, fields, necessary_fields, optional_fields, type_hints, value, type_)
 
+
+def _objloader(l: Loader, fields: Set[str], necessary_fields: Set[str], optional_fields: Set[str], type_hints, value: Dict[str, Any], type_) -> Any:
     try:
         vfields = set(value.keys())
     except AttributeError as e:
@@ -551,6 +544,39 @@ def _namedtupleload(l: Loader, value: Dict[str, Any], type_) -> Any:
         raise TypedloadTypeError(e)
     except ValueError as e:
         raise TypedloadValueError(e)
+
+
+def _namedtupleload(l: Loader, value: Dict[str, Any], type_) -> Any:
+    """
+    This loads a Dict[str, Any] into a NamedTuple.
+    """
+    fields = set(type_.__annotations__.keys())
+    optional_fields = set(getattr(type_, '_field_defaults', {}).keys())
+    type_hints = type_.__annotations__
+    necessary_fields = fields.difference(optional_fields)
+
+    return _objloader(l, fields, necessary_fields, optional_fields, type_hints, value, type_)
+
+
+def _typeddictload(l: Loader, value: Dict[str, Any], type_) -> Any:
+    """
+    This loads a Dict[str, Any] into a NamedTuple.
+    """
+    fields = set(type_.__annotations__.keys())
+    optional_fields = set(getattr(type_, '_field_defaults', {}).keys())
+    type_hints = type_.__annotations__
+
+    if hasattr(type_, '__required_keys__') and hasattr(type_, '__optional_keys__'):
+        # TypedDict, since 3.9
+        necessary_fields = type_.__required_keys__
+        optional_fields = type_.__optional_keys__
+    elif getattr(type_, '__total__', True) == False:
+        # TypedDict, only for 3.8
+        necessary_fields = set()
+    else:
+        necessary_fields = fields.difference(optional_fields)
+
+    return _objloader(l, fields, necessary_fields, optional_fields, type_hints, value, type_)
 
 
 def _unionload(l: Loader, value, type_) -> Any:

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -695,7 +695,6 @@ def _datetimeload(l: Loader, value, type_) -> Union[datetime.date, datetime.time
 def _attrload(l, value, type_):
     if not isinstance(value, dict):
         raise TypedloadTypeError('Expected dictionary, got %s' % tname(type(value)), type_=type_, value=value)
-    value = value.copy()
     names = []
     defaults = {}
     types = {}


### PR DESCRIPTION
Closes: #238

The handler for attrs was creating a fake NamedTuple object on the fly
and then pass it to the NamedTuple handler.

The NamedTuple handler could actually handle also dataclasses and
TypedDict, which led to somewhat complicated branches in the code.

This splits all this mess.

A loader function to do the final checks and create the object is
created and used by all of those handlers, and the handlers only have
to perform name mangling (with the aid of another function) and
decide which fields are necessary and what are the type hints for
all the fields.

This shall make the code quite more readable.