### PR TITLE
    Allow duck typing for attr loading

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 2.13
 ====
 * Separate and simpler handlers for NamedTuple, dataclass, attrs, TypedDict
+* Allow duck typing when loading attr (allow any dict-like class to be used)
 
 2.12
 ====

--- a/tests/test_attrload.py
+++ b/tests/test_attrload.py
@@ -192,12 +192,13 @@ class TestMangling(unittest.TestCase):
 
 class TestAttrExceptions(unittest.TestCase):
 
-    def test_wrongtype(self):
+    def test_wrongtype_simple(self):
         try:
             load(3, Person)
-        except exceptions.TypedloadTypeError:
+        except exceptions.TypedloadAttributeError:
             pass
 
+    def test_wrongtype_nested(self):
         data = {
             'course': 'how to be a corsair',
             'students': [
@@ -207,7 +208,7 @@ class TestAttrExceptions(unittest.TestCase):
         }
         try:
             load(data, Students)
-        except exceptions.TypedloadTypeError as e:
+        except exceptions.TypedloadAttributeError as e:
             assert e.trace[-1].annotation[1] == 1
 
     def test_index(self):

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -465,9 +465,6 @@ def _dataclassload(l: Loader, value: Dict[str, Any], type_) -> Any:
 
 
 def _objloader(l: Loader, fields: Set[str], necessary_fields: Set[str], type_hints, value: Dict[str, Any], type_) -> Any:
-    #FIXME remove this
-    if not isinstance(value, dict):
-        raise TypedloadTypeError('Expected dictionary, got %s' % tname(type(value)), type_=type_, value=value)
     try:
         vfields = set(value.keys())
     except AttributeError as e:


### PR DESCRIPTION
attr handler was checking that the value is a dictionary.
    
While this is the intention, removing the explicit check
allows for dictionary-like classes to be used instead.
    
This is good, I don't want to be like those libraries
that check that paths must be strings and refuse `pathlib.Path` :D