### PR TITLE
Union raises immediately when a non typedload exception is found

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 2.15
 ====
+* Union fails immediately when a non typedload exception is found
 
 2.14
 ====

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -596,7 +596,7 @@ def _unionload(l: Loader, value, type_) -> Any:
             if not l.uniondebugconflict:
                 # Do not try more if we are not debugging
                 break
-        except Exception as e:
+        except TypedloadException as e:
             exceptions.append(e)
 
     if loaded_count == 1:


### PR DESCRIPTION
Basically all handlers are required to only raise subclasses of TypedloadException
at all times and in any case.

A recently met bug was hidden and hard to find because within a union the original
exception was hidden among the other, and then everything was crashing when the
non-typedload exception was inspected to provide information on the issue.

This prevents the later stage failure and fails right away instead.