### PR TITLE
Remove all mypy tests

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,13 @@ typedload (2.15-1) UNRELEASED; urgency=medium
 
   * New upstream release
 
- -- Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>  Mon, 06 Dec 2021 17:45:05 +0100
+ -- Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>  Wed, 15 Dec 2021 00:37:30 +0100
+
+typedload (2.14-2) unstable; urgency=high
+
+  * Remove mypy tests since they periodically fail (Closes: #1001736)
+
+ -- Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>  Wed, 15 Dec 2021 00:37:30 +0100
 
 typedload (2.14-1) unstable; urgency=low
 

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,6 @@ Build-Depends:
  python3-all:any,
  dh-python,
  python3-distutils,
- mypy,
  python3-attr,
  debhelper-compat (= 13)
 Standards-Version: 4.6.0

--- a/debian/rules
+++ b/debian/rules
@@ -5,7 +5,6 @@
 
 override_dh_auto_test:
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
-	make MINIMUM_PYTHON_VERSION=3.7 mypy
 	for pyversion in `py3versions -s`; do \
 		$$pyversion -m tests; \
 	done

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,6 +1,3 @@
-Test-Command:  make MINIMUM_PYTHON_VERSION=3.7 mypy
-Depends: mypy
-
 Test-Command: make test
 Restrictions: allow-stderr
 


### PR DESCRIPTION
mypy keeps making the CI and builds in debian fail periodically.

I've had to do many releases to make it happy, and I've been advised to just stop running those tests on debian as they are not so reliable.