### PR TITLE
contributing file gives freedom to upgrade license

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 ====
 * Union fails immediately when a non typedload exception is found
 * New `make html` target to generate the website
+* Updated CONTRIBUTING file, with details about new licenses from the FSF
 
 2.14
 ====

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -7,4 +7,12 @@ The best way of sending changes is to use git-send-mail to tiposchi@tiscali.it
 
 It is acceptable also to use github's pull request functionality.
 
-Contributors must accept that their changes can use both GPL3 and LGPL3. Currently the license is GPL3 with one exception being made for the company where I work. In the future more LGPL3 exception could be made, but no other license than those will be used.
+Contributors must accept that their changes can use both GPL3 and LGPL3.
+
+Currently the license is GPL3 with one exception being made for the company where I work. In the future more LGPL3 exception could be made, but no other license than those will be used.
+
+In the event that new versions of GPL and LGPL licenses should be published by the Free Software Foundation (FSF) in the future, contributors must accept that their contribution might be licensed with those future versions of GPL and LGPL in addition to the current version.
+
+This will be decided by the owners of the project if and when new versions of the licenses are created and is not automatic, to prevent the case where a new board of the FSF should decide to abandon its mission and grant less freedom to the users.
+
+For new versions that aim at fixing corner cases (such as version 3), they will be used and the software will be available under multiple licenses versions (starting from 3). They will not be adopted should the FSF decide that GPL4 should be a non-copyleft license or other similar spirit altering changes.


### PR DESCRIPTION
After an email exchange with rms (Richard Stallman), who explained to me why it
is important to use GPL3+ license, to allow compatibility, and my worries about
the future of the FSF, I decided to do this compromise:

the version for the license is 3, but should other versions be published I
promise to all contributors that I will relicense as 3 and 4 (or 3, 4 and 5) if
the new licenses do not alter the current spirit of the license.

I change the contributing file so the contributors have to accept this rule and
are aware that their contribution might one day become gpl3+ if such license
should be published, but not before as a blackbox.