### PR TITLE
Add support for loading NewType

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The following things are supported:
  * Path
  * IPv4Address, IPv6Address
  * typing.Any
+ * typing.NewType (requires Python 3.10)
 
 Using Mypy
 ==========

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The following things are supported:
  * Path
  * IPv4Address, IPv6Address
  * typing.Any
- * typing.NewType (requires Python 3.10)
+ * typing.NewType
 
 Using Mypy
 ==========

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -19,10 +19,11 @@
 
 import argparse
 import datetime
+import sys
 from enum import Enum
 from ipaddress import IPv4Address, IPv6Address, IPv6Network, IPv4Network, IPv4Interface, IPv6Interface
 from pathlib import Path
-from typing import Dict, List, NamedTuple, Optional, Set, Tuple, Union, Any
+from typing import Dict, List, NamedTuple, Optional, Set, Tuple, Union, Any, NewType
 import unittest
 
 from typedload import dataloader, load, exceptions
@@ -473,3 +474,14 @@ class TestAny(unittest.TestCase):
         loader = dataloader.Loader()
         o = object()
         assert loader.load(o, Any) is o
+
+
+class TestNewType(unittest.TestCase):
+
+    @unittest.skipIf(sys.version_info < (3, 10, 0), "requires python 3.10 or newer")
+    def test_newtype(self):
+        loader = dataloader.Loader()
+        Foo = NewType("Foo", str)
+        bar = loader.load("bar", Foo)
+        assert bar == "bar"
+        assert type(bar) is str

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -19,7 +19,6 @@
 
 import argparse
 import datetime
-import sys
 from enum import Enum
 from ipaddress import IPv4Address, IPv6Address, IPv6Network, IPv4Network, IPv4Interface, IPv6Interface
 from pathlib import Path
@@ -478,7 +477,6 @@ class TestAny(unittest.TestCase):
 
 class TestNewType(unittest.TestCase):
 
-    @unittest.skipIf(sys.version_info < (3, 10, 0), "requires python 3.10 or newer")
     def test_newtype(self):
         loader = dataloader.Loader()
         Foo = NewType("Foo", str)

--- a/tests/test_typechecks.py
+++ b/tests/test_typechecks.py
@@ -15,9 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # author Salvo "LtWorf" Tomaselli <tiposchi@tiscali.it>
-
 from enum import Enum
-from typing import Dict, FrozenSet, List, NamedTuple, Optional, Set, Tuple, Union, Any
+from typing import Dict, FrozenSet, List, NamedTuple, Optional, Set, Tuple, Union, Any, NewType
 import unittest
 import sys
 
@@ -144,3 +143,9 @@ class TestChecks(unittest.TestCase):
         assert not typechecks.is_any(Tuple[int, ...])
         assert not typechecks.is_any(int)
         assert not typechecks.is_any(List[float])
+
+    @unittest.skipIf(sys.version_info < (3, 10, 0), "requires python 3.10 or newer")
+    def test_isnewtype(self):
+        assert typechecks.is_newtype(NewType("foo", str))
+        assert not typechecks.is_newtype(type(NewType("foo", str)("bar")))
+        assert not typechecks.is_typeddict(str)

--- a/tests/test_typechecks.py
+++ b/tests/test_typechecks.py
@@ -144,7 +144,6 @@ class TestChecks(unittest.TestCase):
         assert not typechecks.is_any(int)
         assert not typechecks.is_any(List[float])
 
-    @unittest.skipIf(sys.version_info < (3, 10, 0), "requires python 3.10 or newer")
     def test_isnewtype(self):
         assert typechecks.is_newtype(NewType("foo", str))
         assert not typechecks.is_newtype(type(NewType("foo", str)("bar")))

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -23,7 +23,6 @@ Module to load data into typed data structures
 
 import datetime
 import ipaddress
-import sys
 from enum import Enum
 from pathlib import Path
 from typing import *
@@ -205,10 +204,8 @@ class Loader:
             (lambda type_: type_ in self.strconstructed, _strconstructload),
             (is_attrs, _attrload),
             (is_any, _anyload),
+            (is_newtype, _newtypeload),
         ]  # type: List[Tuple[Callable[[Any], bool], Callable[[Loader, Any, Type], Any]]]
-
-        if sys.version_info > (3, 10, 0):
-            self.handlers.append((is_newtype, _newtypeload))
 
         for k, v in kwargs.items():
             setattr(self, k, v)

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -23,6 +23,8 @@ Module to load data into typed data structures
 
 import datetime
 import ipaddress
+import sys
+from enum import Enum
 from pathlib import Path
 from typing import *
 
@@ -203,8 +205,10 @@ class Loader:
             (lambda type_: type_ in self.strconstructed, _strconstructload),
             (is_attrs, _attrload),
             (is_any, _anyload),
-            (is_newtype, _newtypeload),
         ]  # type: List[Tuple[Callable[[Any], bool], Callable[[Loader, Any, Type], Any]]]
+
+        if sys.version_info > (3, 10, 0):
+            self.handlers.append((is_newtype, _newtypeload))
 
         for k, v in kwargs.items():
             setattr(self, k, v)
@@ -714,3 +718,7 @@ def _strconstructload(l: Loader, value, type_):
         raise TypedloadTypeError(str(e), type_=type_, value=value)
     except Exception as e:
         raise TypedloadException(str(e), type_=type, value=value)
+
+
+def _newtypeload(l: Loader, value, type_):
+    return l.load(value, type_.__supertype__)

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -23,7 +23,6 @@ Module to load data into typed data structures
 
 import datetime
 import ipaddress
-from enum import Enum
 from pathlib import Path
 from typing import *
 

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -203,6 +203,7 @@ class Loader:
             (lambda type_: type_ in self.strconstructed, _strconstructload),
             (is_attrs, _attrload),
             (is_any, _anyload),
+            (is_newtype, _newtypeload),
         ]  # type: List[Tuple[Callable[[Any], bool], Callable[[Loader, Any, Type], Any]]]
 
         for k, v in kwargs.items():

--- a/typedload/typechecks.py
+++ b/typedload/typechecks.py
@@ -31,9 +31,8 @@ different versions of Python.
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # author Salvo "LtWorf" Tomaselli <tiposchi@tiscali.it>
-
 from enum import Enum
-from typing import Any, Tuple, Union, Set, List, Dict, Type, FrozenSet
+from typing import Any, Tuple, Union, Set, List, Dict, Type, FrozenSet, NewType
 
 
 __all__ = [
@@ -52,6 +51,7 @@ __all__ = [
     'is_tuple',
     'is_union',
     'is_typeddict',
+    'is_newtype',
     'uniontypes',
     'literalvalues',
     'NONETYPE',
@@ -197,6 +197,10 @@ def is_attrs(type_: Type[Any]) -> bool:
     @attr.s decorator
     '''
     return hasattr(type_, '__attrs_attrs__')
+
+
+def is_newtype(type_: Type[Any]) -> bool:
+    return type(type_) == NewType
 
 
 def uniontypes(type_: Type[Any]) -> Tuple[Type[Any], ...]:

--- a/typedload/typechecks.py
+++ b/typedload/typechecks.py
@@ -31,6 +31,7 @@ different versions of Python.
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # author Salvo "LtWorf" Tomaselli <tiposchi@tiscali.it>
+import sys
 from enum import Enum
 from typing import Any, Tuple, Union, Set, List, Dict, Type, FrozenSet, NewType
 
@@ -199,8 +200,13 @@ def is_attrs(type_: Type[Any]) -> bool:
     return hasattr(type_, '__attrs_attrs__')
 
 
-def is_newtype(type_: Type[Any]) -> bool:
-    return type(type_) == NewType
+if sys.version_info > (3, 10, 0):
+    def is_newtype(type_: Type[Any]) -> bool:
+        return type(type_) == NewType
+
+else:
+    def is_newtype(type_: Type[Any]) -> bool:
+        return hasattr(type_, '__supertype__')
 
 
 def uniontypes(type_: Type[Any]) -> Tuple[Type[Any], ...]:


### PR DESCRIPTION
Up to python 3.9 NewType was returning a function which made it hard to access the underlying type at runtime.
In python 3.10 this was however changed to a class, which makes it introspectable via the __supertype__ attribute.
See https://docs.python.org/3/library/typing.html#newtype
And the relevant bpo https://bugs.python.org/issue44353

Introspection of type:
```Python
In [8]: Foo = typing.NewType("Foo", str)

In [9]: print(Foo.__supertype__)
<class 'str'>

In [10]: print(Foo)
__main__.Foo
```

Note that at runtime the type of NewType instances is erased and they just become instances of the supertype.
Which is what happens when using NewType normally as well:
```Python
>>> Foo = typing.NewType("Foo", str)
>>> isinstance("hello", type(Foo("hello")))
True
>>> type(Foo("hello"))
<class 'str'>
>>> isinstance("hello", Foo)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
```

EDIT:

I found a way to add support for older python versions as well.
The old function also had a `__supertype__` attribute which is not used by anything else in python as far as I can tell.

Fixes https://github.com/ltworf/typedload/issues/276