### PR TITLE
Support Python3.10 unions

### DIFF
--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,5 +1,5 @@
 # typedload
-# Copyright (C) 2018-2019 Salvo "LtWorf" Tomaselli
+# Copyright (C) 2018-2022 Salvo "LtWorf" Tomaselli
 #
 # typedload is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -34,6 +34,9 @@ if sys.version_info.minor >= 7:
 if sys.version_info.minor >= 8:
     from .test_literal import *
     from .test_typeddict import *
+if sys.version_info.minor >= 10:
+    from .test_orunion import *
+
 from .test_legacytuples_dataloader import *
 from .test_typechecks import *
 

--- a/tests/test_orunion.py
+++ b/tests/test_orunion.py
@@ -1,0 +1,35 @@
+# typedload
+# Copyright (C) 2022 Salvo "LtWorf" Tomaselli
+#
+# typedload is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# author Salvo "LtWorf" Tomaselli <tiposchi@tiscali.it>
+
+
+from typing import Literal
+import unittest
+
+from typedload import dataloader, load, dump, typechecks
+
+
+class TestOrUnion(unittest.TestCase):
+    '''
+    From Python3.10 unions can be written as A | B.
+
+    That is a completely different internal than Union[A, B]
+    '''
+
+    def test_typechecker(self):
+        assert typechecks.is_union(int | str)
+        assert not typechecks.is_union(2 | 1)

--- a/typedload/typechecks.py
+++ b/typedload/typechecks.py
@@ -34,6 +34,7 @@ different versions of Python.
 import sys
 from enum import Enum
 from typing import Any, Tuple, Union, Set, List, Dict, Type, FrozenSet, NewType
+from types import UnionType
 
 
 __all__ = [
@@ -116,7 +117,7 @@ def is_union(type_: Type[Any]) -> bool:
     Union
     Optional[A]
     '''
-    return getattr(type_, '__origin__', None) == Union
+    return getattr(type_, '__origin__', None) == Union or getattr(type_, '__class__', None) == UnionType
 
 
 def is_optional(type_: Type[Any]) -> bool:


### PR DESCRIPTION
Closes: 292

For some reason instead of being an eyecandy alias, they are completely
different than the `typing.Union` class.