### PR TITLE
Use get_type_hints if pep563 is enabled

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,8 @@
 ====
 * Add is_optional function
 * Support new style union (A | B)
-* Experimental support for PEP563 `__future__.annotations`. READ THE DOCUMENTATION.
+* Experimental support for PEP563 `__future__.annotations`.
+  **READ ABOUT DEFERRED EVALUATION IN THE DOCUMENTATION.**
 
 2.15
 ====

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 ====
 * Add is_optional function
 * Support new style union (A | B)
+* Experimental support for PEP563 `__future__.annotations`. READ THE DOCUMENTATION.
 
 2.15
 ====

--- a/docs/deferred_evaluation.md
+++ b/docs/deferred_evaluation.md
@@ -1,0 +1,34 @@
+Deferred evaluation
+===================
+
+[PEP 563](https://peps.python.org/pep-0563/) defines deferred evaluation of types.
+
+It will most likely be superseeded by [PEP 649](https://peps.python.org/pep-0649/) because of the following issues:
+
+* `eval()` is slow
+* `eval()` might not be present to save space
+* only works for types defined at module level
+
+It is enabled with `from __future__ import annotations`.
+
+When it is enabled you must set `pep563=True` in your loader object, to (hopefully) make it keep working (it will not work in many corner cases).
+
+```python
+from __future__ import annotations
+
+class A(NamedTuple):
+    a: Optional[int]
+
+
+load({'a':1}, A)
+# TypedloadValueError: ForwardRef 'Optional[int]' unknown
+
+load({'a':1}, A, pep563=True)
+# A(a=1)
+```
+
+If you have such a simple case it will work fine. In more complicated cases it will not work. In those cases the solution is to not do the import.
+
+This feature will most likely be removed once the decision for the newer PEP is settled.
+
+It is not part of Python and you should not expect that typedload will keep it.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
         - Examples: examples.md
         - Supported types: supported_types.md
         - Errors: errors.md
+        - Deferred evaluation of types: deferred_evaluation.md
     #- Tutorial:
     - Contriutors:
         - Contributing: CONTRIBUTING.md

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -31,6 +31,7 @@ if sys.version_info.minor > 5:
     from .test_exceptions import *
 if sys.version_info.minor >= 7:
     from .test_dataclass import *
+    from .test_deferred import *
 if sys.version_info.minor >= 8:
     from .test_literal import *
     from .test_typeddict import *

--- a/tests/test_deferred.py
+++ b/tests/test_deferred.py
@@ -1,0 +1,54 @@
+# typedload
+# Copyright (C) 2022 Salvo "LtWorf" Tomaselli
+#
+# typedload is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# author Salvo "LtWorf" Tomaselli <tiposchi@tiscali.it>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import NamedTuple, Optional
+import unittest
+
+from typedload import load
+
+class A(NamedTuple):
+    a: Optional[int]
+
+@dataclass
+class B:
+    a: Optional[int]
+
+class TestDeferred(unittest.TestCase):
+    '''
+    This test should entirely be deleted when the PEP is superseeded.
+    '''
+
+    def test_deferred_named_tuple(self):
+        assert load({'a': None}, A, pep563=True) == A(None)
+        assert load({'a': 3}, A, pep563=True) == A(3)
+
+        with self.assertRaises(ValueError):
+            load({'a': None}, A)
+        with self.assertRaises(ValueError):
+            load({'a': 3}, A)
+
+    def test_deferred_dataclass(self):
+        assert load({'a': None}, B, pep563=True) == B(None)
+        assert load({'a': 3}, B, pep563=True) == B(3)
+
+        with self.assertRaises(TypeError):
+            load({'a': None}, B)
+        with self.assertRaises(TypeError):
+            load({'a': 3}, B)

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -135,6 +135,8 @@ class Loader:
         WARNING: DEPRECATED Support for this might be removed in any future
         release without notice.
 
+        Check deferred evaluation in the documentation for more details.
+
         This will make typedload much slower.
 
         This PEP is broken and superseeded by PEP649.


### PR DESCRIPTION
It's slow, doesn't support nesting, but people seem to use it.

Probably they use it because they never actually use the type hints so it
doesn't matter to them.

This adds a flag to load types using `get_type_hints` which in turn calls
`eval`.

Because this will be superseeded by https://peps.python.org/pep-0649/ the flag 
is starting its life as "deprecated", so I will be free to remove it whenever I
want.

Fixes #291 