### PR TITLE
Make iterator loaders faster

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 ====
 * Support for NotRequired
 * Document performance testing
+* Improve performances when loading iterables
 
 2.16
 ====

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -18,7 +18,7 @@
 
 
 import enum
-from typing import List, NamedTuple, Optional, Tuple
+from typing import List, NamedTuple, Optional, Tuple, Set, FrozenSet
 import unittest
 
 from typedload import dataloader, load, dump, typechecks, exceptions
@@ -106,4 +106,14 @@ class TestExceptionsStr(unittest.TestCase):
                 load(i, Enumeration, basiccast=False, failonextra=True)
             except Exception as e:
                 str(e)
+
+    def test_nested_wrong_type(self):
+        with self.assertRaises(exceptions.TypedloadException):
+            load([[1]], List[List[bytes]])
+        with self.assertRaises(exceptions.TypedloadException):
+            load([[1]], List[Tuple[bytes, ...]])
+        with self.assertRaises(exceptions.TypedloadException):
+            load([[1]], List[Set[bytes]])
+        with self.assertRaises(exceptions.TypedloadException):
+            load([[1]], List[FrozenSet[bytes]])
 

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -354,7 +354,14 @@ def _listload(l: Loader, value, type_) -> List:
     if isinstance(value, dict):
         raise TypedloadTypeError('Unable to load dictionary as a list', value=value, type_=type_)
     t = type_.__args__[0]
-    f = l.handlers[l.index(t)][1]
+    try:
+        f = l.handlers[l.index(t)][1]
+    except ValueError:
+        raise TypedloadTypeError(
+            'Cannot deal with value of type %s' % tname(type_),
+            value=value,
+            type_=type_
+        )
     try:
         # Hopeful load calling the handler directly, skipping load()
         return [f(l, v, t) for v in value]


### PR DESCRIPTION
Instead of calling load() call the handler directly and skip a
function call.

We lose the annotation information because iterators from comprehensions
can't be extracted, and a for loop is much slower than a comprehension.

This will be solved when dropping everything prior to python3.8 when
it will be possible to extract the point when the error occurred in
the iterator.

Until then, basically the list is loaded again but calling load() and
with the annotations if an exception comes, so that the exceptions still
have the details needed to track the problem.

The idea is that exceptions are much rarer than normal condition and so
it makes sense to slow down the exception handling to make the normal
loading much faster.