### PR TITLE
Compare to jsons as well

### DIFF
--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -63,6 +63,33 @@ Found [here](https://pydantic-docs.helpmanual.io/)
     * [Uses float=None without using Optional in its own documentation](https://pydantic-docs.helpmanual.io/usage/models/#recursive-models).
 * Union might do casting when casting is not needed.
 
+jsons
+-----
+
+Found [here](https://github.com/ramonhagenaars/jsons)
+
+I was unable to run the full performance testsuite on this because it doesn't support some needed features, but my preliminary findings are that:
+
+* It is buggy:
+    * This returns an int `jsons.load(1.1, Union[int, float])`
+    * This raises an exception `jsons.load(1.0, int | float)`
+* [Does not support `Literal`](https://github.com/ramonhagenaars/jsons/issues/170)
+* Can't load iterables as lists
+* Exceptions do not have information to find the incorrect data
+* It is incredibly slow:
+
+```python
+# Needed because jsons can't load directly from range()
+data = [i for i in range(3000000)]
+
+# This took 2.5s with jsons and 200ms with typedload
+load(data, list[int])
+
+# This took 20s with jsons and 500ms with typedload
+load(data, list[Union[float,int]])
+```
+
+
 
 dataclasses-json
 ----------------


### PR DESCRIPTION
No perf test added, because jsons doesn't support a bunch of stuff so
it can't really run those tests.

Plus the output it returns in the cases where it works is incorrect
so it makes no sense to compare performance if the value is not
correct.

In any case it's super slow, so better this way, or it'd take me much
longer to run the tests every time.