### PR TITLE
Be able to do uploads after google's "improvements" to security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ html/
 setup.py
 perftest.output
 docs/*_docgen.md
+.token

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ dist: clean setup.py
 
 .PHONY: upload
 upload: pypi
-	twine upload pypi/typedload-`./setup.py --version`.tar.gz
+	twine upload --username __token__ --password `cat .token` pypi/typedload-`./setup.py --version`.tar.gz
 
 deb-pkg: dist
 	mv typedload_`./setup.py --version`.orig.tar.gz* /tmp


### PR DESCRIPTION
After google decided to force 2FA down my throat, it turns out that
twine doesn't actually support 2FA.

So I need to generate a token and store it in a text file to be able
to do uploads.

In theory twine can access the keyring via dbus. In practice it does
not work and just gets stuck.

So in the end to upload, instead of typing my password I'm keeping a
clear text token on my disk. Brilliant :D