### PR TITLE
Split function definition

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 2.19
 ====
 * Fix minor bug about exception raising from string constructed types
+* Simplify type checking functions, defining only the one for the current python version
 
 2.18
 ====

--- a/typedload/typechecks.py
+++ b/typedload/typechecks.py
@@ -109,19 +109,15 @@ NONETYPE = type(None)  # type: Type[Any]
 HAS_UNIONSUBCLASS = False
 
 
-def is_tuple(type_: Type[Any]) -> bool:
-    '''
-    Tuple[int, str]
-    Tuple
-    '''
-    if HAS_TUPLEARGS:
-        # The tuple, Tuple thing is a difference between 3.6 and 3.7
-        # In 3.6 and before, Tuple had an __extra__ field, while Tuple[something]
-        # would have the normal __origin__ field.
-        #
-        # Those apply for Dict, List, Set, Tuple
+if HAS_TUPLEARGS:
+    def is_tuple(type_: Type[Any]) -> bool:
+        '''
+        Tuple[int, str]
+        Tuple
+        '''
         return _generic_type_check(type_, tuple, Tuple)
-    else:
+else:
+    def is_tuple(type_: Type[Any]) -> bool:
         # Old python
         return _issubclass(type_, Tuple) and _issubclass(type_, tuple) == False
 

--- a/typedload/typechecks.py
+++ b/typedload/typechecks.py
@@ -296,11 +296,19 @@ def is_any(type_: Type[Any]) -> bool:
     return type_ == Any
 
 
-def is_notrequired(type_: Type[Any]) -> bool:
-    '''
-    Check if it's typing.NotRequired or typing_extensions.NotRequired
-    '''
-    return getattr(type_, '__origin__', None) == NotRequired and NotRequired is not None
+if NotRequired:
+    def is_notrequired(type_: Type[Any]) -> bool:
+        '''
+        Check if it's typing.NotRequired or typing_extensions.NotRequired
+        '''
+        return getattr(type_, '__origin__', None) == NotRequired
+else:
+    def is_notrequired(type_: Type[Any]) -> bool:
+        '''
+        Returns False.
+        NotRequired is not defined on this platform.
+        '''
+        return False
 
 
 def notrequiredtype(type_: Type[Any]) -> Type[Any]:

--- a/typedload/typechecks.py
+++ b/typedload/typechecks.py
@@ -126,15 +126,26 @@ def is_tuple(type_: Type[Any]) -> bool:
         return _issubclass(type_, Tuple) and _issubclass(type_, tuple) == False
 
 
-def is_union(type_: Type[Any]) -> bool:
-    '''
-    Union[A, B]
-    Union
-    Optional[A]
-    '''
-
+if UnionType:
     # Uniontype is 3.10 defined on 3.10 and None otherwise
-    return getattr(type_, '__origin__', None) == Union or (UnionType and getattr(type_, '__class__', None) == UnionType)
+    def is_union(type_: Type[Any]) -> bool:
+        '''
+        Union[A, B]
+        Union
+        Optional[A]
+        A | B
+        '''
+        return getattr(type_, '__origin__', None) == Union or getattr(type_, '__class__', None) == UnionType
+else:
+    def is_union(type_: Type[Any]) -> bool:
+        '''
+        Union[A, B]
+        Union
+        Optional[A]
+        '''
+
+        # Uniontype is 3.10 defined on 3.10 and None otherwise
+        return getattr(type_, '__origin__', None) == Union
 
 
 def is_optional(type_: Type[Any]) -> bool:


### PR DESCRIPTION
Some type checking functions do different things depending on the
version of python that is in use.

Instead of checking at every call of the function, this just checks
when the module gets imported and just defines the function with
the correct body.