### PR TITLE
Improve loading speed for dictionaries and lists

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Fix minor bug about exception raising from string constructed types
 * Simplify type checking functions, defining only the one for the current python version
 * Fix type definitions of some private functions for compatibility with cython
+* Improved loading speed for dictionaries
+* Improved loading speed for iterators
 
 2.18
 ====


### PR DESCRIPTION
Implement the same optimistic loading in the dictionary handler.
Do not track exceptions and if it fails do it again tracking them.

Thanks to this we skip a bunch of calls.

Also, cache function pointers directly rather than the index to the
function pointer.

This means that there is no need to do handlers[index][1] all the time.
It's not much but it helps.

Also, in the iterator generic loader, use the cache instead of calling
index() to find the handler. This avoids all the calls to the functions
to determine the type.

The result is that less calls happen in the beginning of an iterator
loading. For repeated loads of iterators the difference is quite
noticeable.

![image](https://user-images.githubusercontent.com/1379609/188332179-23956cf5-63c7-4b51-ac6d-f0ccb6f7d98c.png)
