### PR TITLE
Switch to setuptools

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-typedload (2.20) UNRELEASED; urgency=medium
+typedload (2.20-1) UNRELEASED; urgency=medium
 
   * New upstream release
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 typedload (2.20-1) UNRELEASED; urgency=medium
 
   * New upstream release
+  * Switch distutils for setuptools
 
  -- Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>  Mon, 03 Oct 2022 21:32:08 +0200
 

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends:
  debhelper (>= 13),
  python3-all:any,
  dh-python,
- python3-distutils,
+ python3-setuptools,
  python3-attr,
  debhelper-compat (= 13),
  jdupes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 2.20
 ====
+* Switch to setuptools
+  Since python decided to drop the only installation method available within the stdlib
 
 2.19
 ====

--- a/gensetup.py
+++ b/gensetup.py
@@ -67,7 +67,7 @@ AUTHOR = 'Salvo \'LtWorf\' Tomaselli'
 print(
 f'''#!/usr/bin/python3
 # This file is auto generated. Do not modify
-from distutils.core import setup
+from setuptools import setup
 setup(
     name='typedload',
     version={load_version()!r},


### PR DESCRIPTION
Since python so sensibly decided to drop the only existing method of
installing modules present in the stdlib in favour of requiring an
external dependency; which is now always required but needs to be
somehow installed separately.