### PR TITLE
Simple and maybe faster union handler to experiment with

### DIFF
--- a/perftest/load list of floats and ints.py
+++ b/perftest/load list of floats and ints.py
@@ -32,7 +32,7 @@ data = {'data': [i if i % 2 else float(i) for i in range(3000000)]}
 
 if sys.argv[1] == '--typedload':
     from typedload import load
-    f = lambda: load(data, Data)
+    f = lambda: load(data, Data, basiccast=False)
     assert reduce(lambda i,j: i and j, map(lambda i,j: type(i) == type(j), f().data[0:4], [0.0, 1, 2.0, 3]), True)
     print(timeit(f))
 if sys.argv[1] == '--jsons':

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -612,6 +612,14 @@ def _unionload(l: Loader, value: Any, type_) -> Any:
 
     value_type = type(value)
 
+    # Create specialised handlers for simpler unions
+    if not l.basiccast and set(args).issubset(l.basictypes):
+        def _unionbasicload(l: Loader, value: Any, type_):
+            if type(value) in args:
+                return value
+            raise TypedloadValueError('Got %s of type %s, expected %s' % (repr(value), tname(type(value)), tname(type_)), value=value, type_=type_)
+        l._indexcache[type_] = _unionbasicload
+
     # Do not convert basic types, if possible
     if value_type in l.basictypes and value_type in args:
         return value


### PR DESCRIPTION
A union handler for basic types and no casting.

It gets added in the cache to replace the generic union handler.

Preliminary benchmarks show it's no slower. But I want it to be faster
to know if it's worth the complication.