### PR TITLE
Access the tuple of the literals directly

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 2.22
 ====
+* Improve loading time for literals
 
 2.21
 ====

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -321,7 +321,7 @@ def _literalload(l: Loader, value: Any, type_) -> Any:
     Checks if the value is within the allowed literals and
     returns it.
     """
-    if value in literalvalues(type_):
+    if value in type_.__args__:
         return value
     raise TypedloadValueError('Not one of the allowed values in %s' % tname(type_), value=value, type_=type_)
 


### PR DESCRIPTION
Instead of type checking and converting it to a set every single time.

It should be faster and the type check was already done to call the handler.