### PR TITLE
Microsoft decided I must drop support for Python 3.5 and 3.6

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -15,4 +15,4 @@ jobs:
     - name: Install dependencies
       run: pip install mypy types-dataclasses attrs
     - name: mypy
-      run: make MINIMUM_PYTHON_VERSION=3.5 mypy
+      run: make MINIMUM_PYTHON_VERSION=3.7 mypy

--- a/.github/workflows/test_matrix.yml
+++ b/.github/workflows/test_matrix.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11', '3.12.0-alpha.1']
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12.0-alpha.1']
 
     steps:
     - uses: actions/checkout@v2

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,7 @@
+2.21
+====
+* Drop support to Python 3.5 and 3.6
+
 2.20
 ====
 * Switch to setuptools

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -10,7 +10,7 @@ In general, the advantages of typedload over competing libraries are:
 * Easy to extend, even with objects from 3rd party libraries
 * Stable API, breaking changes only happen on major releases (it has happened once since 2018)
 * Supports Union properly
-* Works on python 3.5
+* Works on python 3.5 (typedload <= 2.20)
 * Mypy and similar work without plugins
 * Can use and convert camelCase and snake_case
 * Functional approach
@@ -26,7 +26,7 @@ It also means that mypy will just work out of the box, rather than requiring plu
 
 Instead, typedload works fine with the type annotations from the `typing` module and will work without requiring any changes to the datatypes.
 
-It also works on python 3.5, so projects running on LTS distributions can use it.
+It also works on python 3.5 (until version 2.20), so projects running on LTS distributions can use it.
 
 ### It is easy to extend
 

--- a/gensetup.py
+++ b/gensetup.py
@@ -74,8 +74,6 @@ CLASSIFIERS = [
     'Intended Audience :: Developers',
     'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
     'Typing :: Typed',
-    'Programming Language :: Python :: 3.5',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
@@ -120,7 +118,7 @@ authors = [
 ]
 description = "{DESCRIPTION}"
 readme = "README.md"
-requires-python = ">=3.5"
+requires-python = ">=3.7"
 classifiers = {CLASSIFIERS!r}
 keywords = {KEYWORDS.split(' ')!r}
 license = {{file = "LICENSE"}}

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -21,15 +21,14 @@ import unittest
 import sys
 
 print('Running tests using %s' % sys.version)
-if sys.version_info.major != 3 or sys.version_info.minor < 5:
+if sys.version_info.major != 3 or sys.version_info.minor < 7:
     raise Exception('Only version 3.5 and above supported')
 
-if sys.version_info.minor > 5:
+if sys.version_info.minor >= 7:
     from .test_dataloader import *
     from .test_datadumper import *
     from .test_dumpload import *
     from .test_exceptions import *
-if sys.version_info.minor >= 7:
     from .test_dataclass import *
     from .test_deferred import *
 if sys.version_info.minor >= 8:

--- a/typedload/typechecks.py
+++ b/typedload/typechecks.py
@@ -64,12 +64,7 @@ __all__ = [
 ]
 
 
-try:
-    # Since 3.7
-    from typing import ForwardRef  # type: ignore
-except ImportError:
-    from typing import _ForwardRef as ForwardRef  # type: ignore
-
+from typing import ForwardRef
 
 Literal = None  # type: Any
 _TypedDictMeta = None  # type: Any


### PR DESCRIPTION
I can no longer run tests for those versions, and since I do not intend
to set up my own thing to run the tests on all those Python versions,
I guess it's time to drop support for them.

I had planned to wait about a year more originally.