### PR TITLE
Fairer tests 

### DIFF
--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -50,7 +50,7 @@ It's the only viable alternative to typedload that I've encountered.
 
 * It reuses the same objects in the output, so changing the data might result in subtle bugs if the input data is used again
 * No native support for attrs (but can be manually added by the user)
-* Faster than typedload in most cases
+* Faster than typedload for flat data structures
 
 
 pydantic
@@ -70,6 +70,7 @@ jsons
 
 Found [here](https://github.com/ramonhagenaars/jsons)
 
+* Type safety is not a goal of this project
 * It is buggy:
     * This returns an int `jsons.load(1.1, Union[int, float])`
     * This returns a string `jsons.load(1, Union[str, int])`
@@ -98,8 +99,10 @@ dataclasses-json
 
 Found [here](https://github.com/lidatong/dataclasses-json)
 
+*It is completely useless for type safety and very slow. I can't understand why it has users.*
+
 * It is incredibly slow (20x slower in certain cases)
-* It's buggy (it will be happy to load whatever inside an int field)
+* It doesn't enforce type safety (it will be happy to load whatever inside an int field)
 * Requires to decorate all the classes
 * It is not extensible
 * Has dependencies (marshmallow, marshmallow-enum, typing-inspect)

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -7,26 +7,14 @@ The tests are done on my PC.
 
 Negative values mean that the library could not do the test or returned incorrect values.
 
-Keep in mind that when `jsons` and `dataclasses-json` are outperforming the rest, it usually means they are just passing the data without doing any check for correctness of the types.
-
-Using Python 3.10
------------------
-
-It is possible to see that it is always faster than `pydantic`, and is faster than `apischema` in just one test. `jsons` and `dataclasses-json` are usually very slow, unless they just return the same data without checking anything.
-
-![performance chart](3.10_realistic_union_of_objects_as_namedtuple.svg "Title")
-![performance chart](3.10_load_list_of_floats_and_ints.svg "Title")
-![performance chart](3.10_load_list_of_lists.svg "Title")
-![performance chart](3.10_load_list_of_NamedTuple_objects.svg "Title")
-![performance chart](3.10_load_big_dictionary.svg "Title")
-![performance chart](3.10_load_list_of_ints.svg "Title")
-
 Using Python 3.11
 -----------------
 
-It is possible to see that it is always faster than `pydantic`. `apischema` doesn't work with Python 3.11 so all results are -1. `jsons` and `dataclasses-json` are usually very slow, unless they just return the same data without checking anything.
-
-With Python 3.11 some tests are faster but some other are slower. So it seems that in this use case the performance improvements are a bit hit or miss.
+* `typedload` ![Downloads](https://pepy.tech/badge/typedload)
+* `pydantic` ![Downloads](https://pepy.tech/badge/pydantic) is always slower
+* `apischema` ![Downloads](https://pepy.tech/badge/apischema) is slower for nested data and faster otherwise
+* `jsons` ![Downloads](https://pepy.tech/badge/jsons) is very slow and fails half the tests
+* `dataclasses-json` ![Downloads](https://pepy.tech/badge/dataclasses-json) fails all the tests but is faster in one (yay)
 
 ![performance chart](3.11_realistic_union_of_objects_as_namedtuple.svg "Title")
 ![performance chart](3.11_load_list_of_floats_and_ints.svg "Title")

--- a/perftest/common.py
+++ b/perftest/common.py
@@ -35,3 +35,13 @@ def timeit(f) -> Tuple[float, float]:
         end = time()
         r.append(end - begin)
     return min(r), max(r)
+
+def raised(f) -> bool:
+    '''
+    Returns true if f() raised
+    '''
+    try:
+        f()
+        return False
+    except:
+        return True

--- a/perftest/load big dictionary.py
+++ b/perftest/load big dictionary.py
@@ -48,13 +48,14 @@ elif sys.argv[1] == '--pydantic':
     print(timeit(f))
 elif sys.argv[1] == '--apischema':
     import apischema
+    import copy
     # apischema will return a pointer to the same list, which is a bug
     # that can lead to data corruption, but makes it very fast
     # so level the field by copying the list
     def f():
         r = apischema.deserialize(Data, data)
-        r.data.copy()
-        return r
+        d = copy.deepcopy(r)
+        return d
     assert f().data['0'][0] == '0'
     print(timeit(f))
 elif sys.argv[1] == '--dataclass_json':

--- a/perftest/load big dictionary.py
+++ b/perftest/load big dictionary.py
@@ -19,26 +19,19 @@
 from typing import NamedTuple
 import sys
 
-from common import timeit
+from common import timeit, raised
 
 
 class Data(NamedTuple):
     data: dict[str, dict[int, str]]
 
 
-data = {'data': { str(k): {i: str(i) for i in range(300)} for k in range(3000)}}
-
-
 if sys.argv[1] == '--typedload':
     from typedload import load
     f = lambda: load(data, Data)
-    assert f().data['0'][0] == '0'
-    print(timeit(f))
 elif sys.argv[1] == '--jsons':
     from jsons import load
     f = lambda: load(data, Data)
-    assert f().data['0'][0] == '0'
-    print(timeit(f))
 elif sys.argv[1] == '--pydantic':
     import pydantic
     class DataPy(pydantic.BaseModel):
@@ -56,8 +49,6 @@ elif sys.argv[1] == '--apischema':
         r = apischema.deserialize(Data, data)
         d = copy.deepcopy(r)
         return d
-    assert f().data['0'][0] == '0'
-    print(timeit(f))
 elif sys.argv[1] == '--dataclass_json':
     from dataclasses import dataclass
     from dataclasses_json import dataclass_json
@@ -66,5 +57,15 @@ elif sys.argv[1] == '--dataclass_json':
     class Data:
         data: dict[str, dict[int, str]]
     f = lambda: Data.from_dict(data)
-    assert f().data['0'][0] == '0'
-    print(timeit(f))
+
+# Functionality test
+data = {'data': { str(k): {i: str(i) for i in range(3)} for k in range(30)}}
+assert f().data['0'][0] == '0'
+
+# Test it doesn't just pass any value
+data = {'data': {'ciccio', 'asd'}}
+assert raised(f)
+
+# Performance test
+data = {'data': { str(k): {i: str(i) for i in range(300)} for k in range(3000)}}
+print(timeit(f))

--- a/perftest/load list of NamedTuple objects.py
+++ b/perftest/load list of NamedTuple objects.py
@@ -19,7 +19,7 @@
 from typing import List, NamedTuple
 import sys
 
-from common import timeit
+from common import timeit, raised
 
 
 
@@ -31,19 +31,12 @@ class Data(NamedTuple):
     data: List[Child]
 
 
-data = {'data': [{'value': i} for i in range(300000)]}
-
-
 if sys.argv[1] == '--typedload':
     from typedload import load
     f = lambda: load(data, Data)
-    assert f().data[1].value == 1
-    print(timeit(f))
 elif sys.argv[1] == '--jsons':
     from jsons import load
     f = lambda: load(data, Data)
-    assert f().data[1].value == 1
-    print(timeit(f))
 elif sys.argv[1] == '--pydantic':
     import pydantic
     class ChildPy(pydantic.BaseModel):
@@ -51,13 +44,9 @@ elif sys.argv[1] == '--pydantic':
     class DataPy(pydantic.BaseModel):
         data: List[ChildPy]
     f = lambda: DataPy(**data)
-    assert f().data[1].value == 1
-    print(timeit(f))
 elif sys.argv[1] == '--apischema':
     import apischema
     f = lambda: apischema.deserialize(Data, data)
-    assert f().data[1].value == 1
-    print(timeit(f))
 elif sys.argv[1] == '--dataclass_json':
     from dataclasses import dataclass
     from dataclasses_json import dataclass_json
@@ -71,5 +60,13 @@ elif sys.argv[1] == '--dataclass_json':
     class Data:
         data: List[Child]
     f = lambda: Data.from_dict(data)
-    assert f().data[1].value == 1
-    print(timeit(f))
+
+data = {'data': [{'value': i} for i in range(30)]}
+assert f().data[1].value == 1
+
+data = {'data': [{'value': 'qwe'} for i in range(30)]}
+assert raised(f)
+
+data = {'data': [{'value': i} for i in range(300000)]}
+print(timeit(f))
+

--- a/perftest/load list of lists.py
+++ b/perftest/load list of lists.py
@@ -19,33 +19,24 @@
 from typing import NamedTuple
 import sys
 
-from common import timeit
+from common import timeit, raised
 
 
 class Data(NamedTuple):
     data: list[list[int]]
 
 
-data = {'data': [[1, 2, 3] for _ in range(300000)]}
-
-
 if sys.argv[1] == '--typedload':
     from typedload import load
     f = lambda: load(data, Data)
-    assert f().data[0][0] == 1
-    print(timeit(f))
 elif sys.argv[1] == '--jsons':
     from jsons import load
     f = lambda: load(data, Data)
-    assert f().data[0][0] == 1
-    print(timeit(f))
 elif sys.argv[1] == '--pydantic':
     import pydantic
     class DataPy(pydantic.BaseModel):
         data: list[list[int]]
     f = lambda: DataPy(**data)
-    assert f().data[0][0] == 1
-    print(timeit(f))
 elif sys.argv[1] == '--apischema':
     import apischema
     import copy\
@@ -56,8 +47,6 @@ elif sys.argv[1] == '--apischema':
         r = apischema.deserialize(Data, data)
         d = copy.deepcopy(r)
         return d
-    assert f().data[0][0] == 1
-    print(timeit(f))
 elif sys.argv[1] == '--dataclass_json':
     from dataclasses import dataclass
     from dataclasses_json import dataclass_json
@@ -66,5 +55,13 @@ elif sys.argv[1] == '--dataclass_json':
     class Data:
         data: list[list[int]]
     f = lambda: Data.from_dict(data)
-    assert f().data[0][0] == 1
-    print(timeit(f))
+
+
+data = {'data': [[1, 2, 3] for _ in range(30)]}
+assert f().data[0][0] == 1
+
+data = {'data': [['q']]}
+assert raised(f)
+
+data = {'data': [[1, 2, 3] for _ in range(300000)]}
+print(timeit(f))

--- a/perftest/load list of lists.py
+++ b/perftest/load list of lists.py
@@ -48,13 +48,14 @@ elif sys.argv[1] == '--pydantic':
     print(timeit(f))
 elif sys.argv[1] == '--apischema':
     import apischema
+    import copy\
     # apischema will return a pointer to the same list, which is a bug
     # that can lead to data corruption, but makes it very fast
     # so level the field by copying the list
     def f():
         r = apischema.deserialize(Data, data)
-        d = [i.copy() for i in r.data]
-        return r
+        d = copy.deepcopy(r)
+        return d
     assert f().data[0][0] == 1
     print(timeit(f))
 elif sys.argv[1] == '--dataclass_json':

--- a/perftest/realistic union of objects as namedtuple.py
+++ b/perftest/realistic union of objects as namedtuple.py
@@ -20,7 +20,7 @@ from typing import Tuple, Union, Literal, NamedTuple
 import sys
 from dataclasses import dataclass
 
-from common import timeit
+from common import timeit, raised
 
 @dataclass(frozen=True)
 class EventMessage:
@@ -97,21 +97,14 @@ events = [
         'receiver': '3145',
         'url': 'http://url',
     },
-] * 50000
-
-data = {'data': events}
-
+]
 
 if sys.argv[1] == '--typedload':
     from typedload import load
     f = lambda: load(data, EventList)
-    assert f().data[2].sender == '3141'
-    print(timeit(f))
 elif sys.argv[1] == '--jsons':
     from jsons import load
     f = lambda: load(data, EventList)
-    assert f().data[2].sender == '3141'
-    print(timeit(f))
 elif sys.argv[1] == '--pydantic':
     import pydantic
     class EventMessagePy(pydantic.BaseModel):
@@ -144,13 +137,9 @@ elif sys.argv[1] == '--pydantic':
     class EventListPy(pydantic.BaseModel):
         data: Tuple[EventPy, ...]
     f = lambda: EventListPy(**data)
-    assert f().data[2].sender == '3141'
-    print(timeit(f))
 elif sys.argv[1] == '--apischema':
     import apischema
     f = lambda: apischema.deserialize(EventList, data)
-    assert f().data[2].sender == '3141'
-    print(timeit(f))
 elif sys.argv[1] == '--dataclass_json':
     from dataclasses_json import dataclass_json
     @dataclass_json
@@ -158,8 +147,6 @@ elif sys.argv[1] == '--dataclass_json':
     class EventList:
         data: Tuple[Event, ...]
     f = lambda: EventList.from_dict(data)
-    assert f().data[2].sender == '3141'
-    print(timeit(f))
 elif sys.argv[1] == '--apischema-discriminator':
     import apischema
     try:
@@ -173,6 +160,10 @@ elif sys.argv[1] == '--apischema-discriminator':
         class DiscriminatedEventList(NamedTuple):
             data: Tuple[Annotated[Event, discriminator], ...]
         f = lambda: apischema.deserialize(DiscriminatedEventList, data)
-        assert f().data[2].sender == '3141'
-        print(timeit(f))
+
+data = {'data': events * 5}
+assert f().data[2].sender == '3141'
+
+data = {'data': events * 50000}
+print(timeit(f))
 


### PR DESCRIPTION
Add a positive and negative test to make sure that the result is 
actually correct.
 
Use deepcopy for apischema, since it cheats by returning the same
pointers when possible, creating a risk for strange bugs.
 
Add download counters.