### PR TITLE
Make dumps faster

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 2.21
 ====
 * Drop support to Python 3.5 and 3.6
+* Improve performance for dumping
 
 2.20
 ====

--- a/tests/test_datadumper.py
+++ b/tests/test_datadumper.py
@@ -141,7 +141,6 @@ class TestHandlersDumper(unittest.TestCase):
     def test_replace_handler(self):
         dumper = datadumper.Dumper()
         index = dumper.index([])
-        assert dumper.dump([11]) == [11]
         dumper.handlers[index] = (dumper.handlers[index][0], lambda *args: 3)
         assert dumper.dump([11]) == 3
 

--- a/typedload/datadumper.py
+++ b/typedload/datadumper.py
@@ -130,8 +130,8 @@ class Dumper:
 
         ]  # type: List[Tuple[Callable[[Any], bool],Callable[['Dumper', Any], Any]]]
 
-        self._handlerscache = {}
-        self._dataclasscache = {}
+        self._handlerscache = {}  # type: Dict[Type[Any], Callable[['Dumper', Any], Any]]
+        self._dataclasscache = {}  # type: Dict[Type[Any], Tuple[Set[str], Dict[str, Any]]]
 
         for k, v in kwargs.items():
             setattr(self, k, v)

--- a/typedload/datadumper.py
+++ b/typedload/datadumper.py
@@ -130,9 +130,10 @@ class Dumper:
 
         ]  # type: List[Tuple[Callable[[Any], bool],Callable[['Dumper', Any], Any]]]
 
+        self._handlerscache = {}
+
         for k, v in kwargs.items():
             setattr(self, k, v)
-
 
     def index(self, value: Any) -> int:
         """
@@ -157,8 +158,12 @@ class Dumper:
         Dump the typed data structure into its
         untyped equivalent.
         """
-        index = self.index(value)
-        func = self.handlers[index][1]
+        t = type(value)
+        func = self._handlerscache.get(t)
+        if func is None:
+            index = self.index(value)
+            func = self.handlers[index][1]
+            self._handlerscache[t] = func
         return func(self, value)
 
 


### PR DESCRIPTION
Cache the handler to use.

Cache the introspection for the dataclass.

This makes it much faster.