### PR TITLE
Use type annotations to make dump faster

### DIFF
--- a/typedload/datadumper.py
+++ b/typedload/datadumper.py
@@ -184,7 +184,7 @@ def _attrdump(d, value) -> Dict[str, Any]:
     return r
 
 
-def _datetimedump(l, value: Union[datetime.time, datetime.date, datetime.datetime]):
+def _datetimedump(d: Dumper, value: Union[datetime.time, datetime.date, datetime.datetime]):
     # datetime is subclass of date
     if isinstance(value, datetime.date) and not isinstance(value, datetime.datetime):
         return [value.year, value.month, value.day]
@@ -196,16 +196,16 @@ def _datetimedump(l, value: Union[datetime.time, datetime.date, datetime.datetim
     return [value.year, value.month, value.day, value.hour, value.minute, value.second, value.microsecond]
 
 
-def _namedtupledump(l, value):
+def _namedtupledump(d: Dumper, value) -> Dict[str, Any]:
     field_defaults = getattr(value, '_field_defaults', {})
     # Named tuple, skip default values
     return {
-        k: l.dump(v) for k, v in value._asdict().items()
-        if not l.hidedefault or k not in field_defaults or field_defaults[k] != v
+        k: d.dump(v) for k, v in value._asdict().items()
+        if not d.hidedefault or k not in field_defaults or field_defaults[k] != v
     }
 
 
-def _dataclassdump(d, value):
+def _dataclassdump(d: Dumper, value) -> Dict[str, Any]:
     t = type(value)
     cached = d._dataclasscache.get(t)
     if cached is None:

--- a/typedload/datadumper.py
+++ b/typedload/datadumper.py
@@ -129,7 +129,7 @@ class Dumper:
             (lambda value: isinstance(value, (datetime.date, datetime.time)), _datetimedump),
             (lambda value: type(value) in self.strconstructed, lambda l, value, t: str(value)),
 
-        ]  # type: List[Tuple[Callable[[Any], bool],Callable[['Dumper', Any], Any]]]
+        ]  # type: List[Tuple[Callable[[Any], bool], Callable[['Dumper', Any, Any], Any]|Callable[['Dumper', Any], Any]]]
 
         self._handlerscache = {}  # type: Dict[Type[Any], Callable[['Dumper', Any], Any]|Callable[['Dumper', Any, Any], Any]]
         self._dataclasscache = {}  # type: Dict[Type[Any], Tuple[Set[str], Dict[str, Any], Dict[str, Any]]]
@@ -171,11 +171,11 @@ class Dumper:
             # It has no type parameter
             # TODO make all handlers require it in 3.0
             if len(signature(f).parameters) == 2:
-                func = lambda d, v, _: f(d, v)
+                func = lambda d, v, _: f(d, v)  # type: ignore
             else:
                 func = f
             self._handlerscache[t] = func
-        return func(self, value, annotated_type)
+        return func(self, value, annotated_type)  # type: ignore
 
 
 def _attrdump(d, value, t) -> Dict[str, Any]:
@@ -245,7 +245,8 @@ def _iteratordump(d: Dumper, value: Any, t: Any) -> List[Any]:
             r.append(d.dump(next(iterator), itertype[0]))
         except StopIteration:
             return []
-        f = d._handlerscache[itertype[0]]
-        return r.extend((f(d, i, itertype[0]) for i in iterator))
+        f = d._handlerscache[itertype[0]]  # type: ignore
+        r.extend((f(d, i, itertype[0]) for i in iterator))  # type: ignore
+        return r
     else:
         return [d.dump(i) for i in value]

--- a/typedload/datadumper.py
+++ b/typedload/datadumper.py
@@ -239,13 +239,13 @@ def _iteratordump(d: Dumper, value: Any, t: Any) -> List[Any]:
     itertype = getattr(t, '__args__', (Any, ))
     if len(itertype) == 1 and (itertype[0] in d.basictypes):
         r = []
-        # Call one iteration with dump, to populate the cache
         iterator = iter(value)
         try:
+            # Call one iteration with dump, to populate the cache
             r.append(d.dump(next(iterator), itertype[0]))
         except StopIteration:
             return []
         f = d._handlerscache[itertype[0]]
-        return r + [f(d, i, itertype[0]) for i in iterator]
+        return r.extend((f(d, i, itertype[0]) for i in iterator))
     else:
         return [d.dump(i) for i in value]


### PR DESCRIPTION
Pass type annotations to dump handlers. This can make dump faster
in some common cases.