### PR TITLE
Correct `msgspec` comparisons in docs

### DIFF
--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -134,9 +134,11 @@ msgspec
 
 Found [here](https://jcristharif.com/msgspec/)
 
-
-* Decodes json directly, which is faster, but it means it can't be used with bson, yaml, and whatever else
-* It can't run the performance tests since it doesn't support unions (not even tagged with Literal)
+* It doesn't support PyPy.
+* It has [some restrictions on unions](https://jcristharif.com/msgspec/supported-types.html#union-optional).
+  In particular unions containing multiple dataclasses aren't supported; to
+  represent unions of object types you need to use their ``msgspec.Struct``
+  type.
 
 ```python
 TypeError: Type unions may not contain more than one dataclass type - type `A | B` is not supported

--- a/perftest/dump objects.py
+++ b/perftest/dump objects.py
@@ -52,6 +52,9 @@ elif sys.argv[1] == '--pydantic':
     class PPossessions(pydantic.BaseModel):
         possessions: list[Union[House, Car]]
     f = lambda: PPossessions(possessions=data.possessions).dict()
+elif sys.argv[1] == '--msgspec':
+    import msgspec
+    f = lambda: msgspec.to_builtins(data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/fail load list of floats and ints.py
+++ b/perftest/fail load list of floats and ints.py
@@ -37,6 +37,11 @@ elif sys.argv[1] == '--pydantic':
     class DataPy(pydantic.BaseModel, smart_union=True):
         data: List[Union[int, float]]
     f = lambda: DataPy(**data)
+elif sys.argv[1] == '--msgspec':
+    import msgspec
+    class Data(msgspec.Struct):
+        data: List[Union[int, float]]
+    f = lambda: msgspec.from_builtins(data, Data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/fail realistic union of objects as namedtuple.py
+++ b/perftest/fail realistic union of objects as namedtuple.py
@@ -137,6 +137,33 @@ elif sys.argv[1] == '--pydantic':
     class EventListPy(pydantic.BaseModel):
         data: Tuple[EventPy, ...]
     f = lambda: EventListPy(**data)
+elif sys.argv[1] == '--msgspec':
+    import msgspec
+    class EventMessage(msgspec.Struct, tag="message"):
+        timestamp: float
+        text: str
+        sender: str
+        receiver: str
+    class EventFile(msgspec.Struct, tag="file"):
+        timestamp: float
+        filename: str
+        sender: str
+        receiver: str
+        url: str
+    class EventPing(msgspec.Struct, tag="ping"):
+        timestamp: float
+    class EventEnter(msgspec.Struct, tag="enter"):
+        timestamp: float
+        sender: str
+        room: int
+    class EventExit(msgspec.Struct, tag="exit"):
+        timestamp: float
+        sender: str
+        room: int
+    Event = Union[EventExit, EventEnter,EventMessage, EventPing, EventFile]
+    class EventList(msgspec.Struct):
+        data: Tuple[Event, ...]
+    f = lambda: msgspec.from_builtins(data, EventList)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load big dictionary.py
+++ b/perftest/load big dictionary.py
@@ -39,6 +39,11 @@ elif sys.argv[1] == '--pydantic':
     f = lambda: DataPy(**data)
     assert f().data['0'][0] == '0'
     print(timeit(f))
+elif sys.argv[1] == '--msgspec':
+    import msgspec
+    class Data(msgspec.Struct):
+        data: dict[str, dict[int, str]]
+    f = lambda: msgspec.from_builtins(data, Data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load list of NamedTuple objects.py
+++ b/perftest/load list of NamedTuple objects.py
@@ -44,6 +44,13 @@ elif sys.argv[1] == '--pydantic':
     class DataPy(pydantic.BaseModel):
         data: List[ChildPy]
     f = lambda: DataPy(**data)
+elif sys.argv[1] == '--msgspec':
+    import msgspec
+    class Child(msgspec.Struct):
+        value: int
+    class Data(msgspec.Struct):
+        data: List[Child]
+    f = lambda: msgspec.from_builtins(data, Data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load list of dataclass objects.py
+++ b/perftest/load list of dataclass objects.py
@@ -45,6 +45,13 @@ elif sys.argv[1] == '--pydantic':
     class DataPy(pydantic.BaseModel):
         data: List[ChildPy]
     print(timeit(lambda: DataPy(**data)))
+elif sys.argv[1] == '--msgspec':
+    import msgspec
+    class Child(msgspec.Struct):
+        value: int
+    class Data(msgspec.Struct):
+        data: List[Child]
+    print(timeit(lambda: msgspec.from_builtins(data, Data)))
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load list of floats and ints.py
+++ b/perftest/load list of floats and ints.py
@@ -37,6 +37,11 @@ elif sys.argv[1] == '--pydantic':
     class DataPy(pydantic.BaseModel, smart_union=True):
         data: List[Union[int, float]]
     f = lambda: DataPy(**data)
+elif sys.argv[1] == '--msgspec':
+    import msgspec
+    class Data(msgspec.Struct):
+        data: List[Union[int, float]]
+    f = lambda: msgspec.from_builtins(data, Data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load list of ints.py
+++ b/perftest/load list of ints.py
@@ -37,6 +37,11 @@ elif sys.argv[1] == '--pydantic':
     class DataPy(pydantic.BaseModel):
         data: List[int]
     f = lambda: DataPy(**data)
+elif sys.argv[1] == '--msgspec':
+    import msgspec
+    class Data(msgspec.Struct):
+        data: List[int]
+    f = lambda: msgspec.from_builtins(data, Data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load list of lists.py
+++ b/perftest/load list of lists.py
@@ -37,6 +37,11 @@ elif sys.argv[1] == '--pydantic':
     class DataPy(pydantic.BaseModel):
         data: list[list[int]]
     f = lambda: DataPy(**data)
+elif sys.argv[1] == '--msgspec':
+    import msgspec
+    class Data(msgspec.Struct):
+        data: list[list[int]]
+    f = lambda: msgspec.from_builtins(data, Data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/performance.py
+++ b/perftest/performance.py
@@ -52,7 +52,7 @@ def main():
         'fail load list of floats and ints',
     ]
 
-    extlibs = ['pydantic', 'apischema']
+    extlibs = ['pydantic', 'apischema', 'msgspec']
 
     outdir = Path('perftest.output')
     if not outdir.exists():

--- a/perftest/realistic union of objects as namedtuple.py
+++ b/perftest/realistic union of objects as namedtuple.py
@@ -137,6 +137,33 @@ elif sys.argv[1] == '--pydantic':
     class EventListPy(pydantic.BaseModel):
         data: Tuple[EventPy, ...]
     f = lambda: EventListPy(**data)
+elif sys.argv[1] == '--msgspec':
+    import msgspec
+    class EventMessage(msgspec.Struct, tag="message"):
+        timestamp: float
+        text: str
+        sender: str
+        receiver: str
+    class EventFile(msgspec.Struct, tag="file"):
+        timestamp: float
+        filename: str
+        sender: str
+        receiver: str
+        url: str
+    class EventPing(msgspec.Struct, tag="ping"):
+        timestamp: float
+    class EventEnter(msgspec.Struct, tag="enter"):
+        timestamp: float
+        sender: str
+        room: int
+    class EventExit(msgspec.Struct, tag="exit"):
+        timestamp: float
+        sender: str
+        room: int
+    Event = Union[EventExit, EventEnter, EventMessage, EventPing, EventFile]
+    class EventList(msgspec.Struct):
+        data: Tuple[Event, ...]
+    f = lambda: msgspec.from_builtins(data, EventList)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True
@@ -167,4 +194,3 @@ assert f().data[2].sender == '3141'
 
 data = {'data': events * 50000}
 print(timeit(f))
-


### PR DESCRIPTION
Hello. From [conversation in this reddit thread](https://www.reddit.com/r/Python/comments/11bl6u5/comment/ja25eei/?utm_source=reddit&utm_medium=web2x&context=3), there's a bit of confusion here about what the limitations of `msgspec` are. In an attempt to correct them, I've also added `msgspec` to your benchmarks. I don't particularly care whether you accept the benchmark changes or not, the main point here is to fix the docs.

- `msgspec` *does* support YAML and BSON. `yaml` support is builtin in the `msgspec.yaml` module, BSON support could be added through wrapping a serialization lib (e.g. [bson](https://pypi.org/project/bson/)) with [converters](https://jcristharif.com/msgspec/converters.html). Saying this isn't supported is untrue.
- While there are restrictions on Unions, all unions present in your performance tests are also supported by msgspec. Unions containing multiple dataclasses are unsupported, unions of multiple (tagged) `msgspec.Struct` types are. Since you're willing to use `pydantic.BaseModel` for pydantic comparisons, I see no reason not to use `msgpsec.Struct` for msgspec comparisons.

Since your comparison doc seems mostly about documenting limitations of other libraries, I've added a few limitations of `msgspec`, rather than pointing out any of its benefits. Please feel free to amend these as you see fit, provided they're factually correct.

A few `perftest` result comparisons:

```bash
$ python perftest/realistic\ union\ of\ objects\ as\ namedtuple.py --msgspec
(0.04112465900107054, 0.05047721300070407)
$ python perftest/realistic\ union\ of\ objects\ as\ namedtuple.py --typedload
(2.534784483999829, 2.540800915994623)
```

```bash
$ python perftest/load\ list\ of\ dataclass\ objects.py --msgspec
(0.023318380997807253, 0.03230420899490127)
$ python perftest/load\ list\ of\ dataclass\ objects.py --typedload
(0.9738546360022156, 0.9953590620061732)
```

I would have included a plot in the PR, but I couldn't get the plots to generate properly. Saw some error about "STRING operator applied to undefined or non-STRING variable". I'm hoping/assuming that's either user error on my part, or a version gnuplot incompatibility issue and not a bug I've introduced.

Anyway, as I said above, the main point of this PR is to correct some falsehoods about msgspec listed in the docs. Whether you also accept the addition to the benchmarks is up to you.