### PR TITLE
Remove msgspec from benchmarks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,6 @@
 ====
 * Remove `jsons` and `dataclasses-json` from benchmarks.
   They were too slow to be a useful comparison.
-* Add benchmark for `msgspec`
 
 2.22
 ====

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -10,7 +10,6 @@ Negative values mean that the library could not do the test or returned incorrec
 * `typedload` ![Downloads](https://pepy.tech/badge/typedload)
 * `pydantic` ![Downloads](https://pepy.tech/badge/pydantic) is always slower
 * `apischema` ![Downloads](https://pepy.tech/badge/apischema) is slower for nested data and faster otherwise
-* `msgspec` ![Downloads](https://pepy.tech/badge/msgspec) Very fast, implemented in C
 
 Using Python 3.11
 -----------------
@@ -48,7 +47,7 @@ Generate the performance chart locally.
 ```bash
 python3 -m venv perfvenv
 . perfvenv/bin/activate
-pip install apischema pydantic attrs msgspec
+pip install apischema pydantic attrs
 export PYTHONPATH=$(pwd)
 make gnuplot
 ```

--- a/perftest/dump objects.py
+++ b/perftest/dump objects.py
@@ -52,9 +52,6 @@ elif sys.argv[1] == '--pydantic':
     class PPossessions(pydantic.BaseModel):
         possessions: list[Union[House, Car]]
     f = lambda: PPossessions(possessions=data.possessions).dict()
-elif sys.argv[1] == '--msgspec':
-    import msgspec
-    f = lambda: msgspec.to_builtins(data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/fail load list of floats and ints.py
+++ b/perftest/fail load list of floats and ints.py
@@ -37,11 +37,6 @@ elif sys.argv[1] == '--pydantic':
     class DataPy(pydantic.BaseModel, smart_union=True):
         data: List[Union[int, float]]
     f = lambda: DataPy(**data)
-elif sys.argv[1] == '--msgspec':
-    import msgspec
-    class Data(msgspec.Struct):
-        data: List[Union[int, float]]
-    f = lambda: msgspec.from_builtins(data, Data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/fail realistic union of objects as namedtuple.py
+++ b/perftest/fail realistic union of objects as namedtuple.py
@@ -137,33 +137,6 @@ elif sys.argv[1] == '--pydantic':
     class EventListPy(pydantic.BaseModel):
         data: Tuple[EventPy, ...]
     f = lambda: EventListPy(**data)
-elif sys.argv[1] == '--msgspec':
-    import msgspec
-    class EventMessage(msgspec.Struct, tag="message"):
-        timestamp: float
-        text: str
-        sender: str
-        receiver: str
-    class EventFile(msgspec.Struct, tag="file"):
-        timestamp: float
-        filename: str
-        sender: str
-        receiver: str
-        url: str
-    class EventPing(msgspec.Struct, tag="ping"):
-        timestamp: float
-    class EventEnter(msgspec.Struct, tag="enter"):
-        timestamp: float
-        sender: str
-        room: int
-    class EventExit(msgspec.Struct, tag="exit"):
-        timestamp: float
-        sender: str
-        room: int
-    Event = Union[EventExit, EventEnter,EventMessage, EventPing, EventFile]
-    class EventList(msgspec.Struct):
-        data: Tuple[Event, ...]
-    f = lambda: msgspec.from_builtins(data, EventList)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load big dictionary.py
+++ b/perftest/load big dictionary.py
@@ -39,11 +39,6 @@ elif sys.argv[1] == '--pydantic':
     f = lambda: DataPy(**data)
     assert f().data['0'][0] == '0'
     print(timeit(f))
-elif sys.argv[1] == '--msgspec':
-    import msgspec
-    class Data(msgspec.Struct):
-        data: dict[str, dict[int, str]]
-    f = lambda: msgspec.from_builtins(data, Data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load list of NamedTuple objects.py
+++ b/perftest/load list of NamedTuple objects.py
@@ -44,13 +44,6 @@ elif sys.argv[1] == '--pydantic':
     class DataPy(pydantic.BaseModel):
         data: List[ChildPy]
     f = lambda: DataPy(**data)
-elif sys.argv[1] == '--msgspec':
-    import msgspec
-    class Child(msgspec.Struct):
-        value: int
-    class Data(msgspec.Struct):
-        data: List[Child]
-    f = lambda: msgspec.from_builtins(data, Data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load list of dataclass objects.py
+++ b/perftest/load list of dataclass objects.py
@@ -45,13 +45,6 @@ elif sys.argv[1] == '--pydantic':
     class DataPy(pydantic.BaseModel):
         data: List[ChildPy]
     print(timeit(lambda: DataPy(**data)))
-elif sys.argv[1] == '--msgspec':
-    import msgspec
-    class Child(msgspec.Struct):
-        value: int
-    class Data(msgspec.Struct):
-        data: List[Child]
-    print(timeit(lambda: msgspec.from_builtins(data, Data)))
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load list of floats and ints.py
+++ b/perftest/load list of floats and ints.py
@@ -37,11 +37,6 @@ elif sys.argv[1] == '--pydantic':
     class DataPy(pydantic.BaseModel, smart_union=True):
         data: List[Union[int, float]]
     f = lambda: DataPy(**data)
-elif sys.argv[1] == '--msgspec':
-    import msgspec
-    class Data(msgspec.Struct):
-        data: List[Union[int, float]]
-    f = lambda: msgspec.from_builtins(data, Data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load list of ints.py
+++ b/perftest/load list of ints.py
@@ -37,11 +37,6 @@ elif sys.argv[1] == '--pydantic':
     class DataPy(pydantic.BaseModel):
         data: List[int]
     f = lambda: DataPy(**data)
-elif sys.argv[1] == '--msgspec':
-    import msgspec
-    class Data(msgspec.Struct):
-        data: List[int]
-    f = lambda: msgspec.from_builtins(data, Data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load list of lists.py
+++ b/perftest/load list of lists.py
@@ -37,11 +37,6 @@ elif sys.argv[1] == '--pydantic':
     class DataPy(pydantic.BaseModel):
         data: list[list[int]]
     f = lambda: DataPy(**data)
-elif sys.argv[1] == '--msgspec':
-    import msgspec
-    class Data(msgspec.Struct):
-        data: list[list[int]]
-    f = lambda: msgspec.from_builtins(data, Data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/performance.py
+++ b/perftest/performance.py
@@ -52,7 +52,7 @@ def main():
         'fail load list of floats and ints',
     ]
 
-    extlibs = ['pydantic', 'apischema', 'msgspec']
+    extlibs = ['pydantic', 'apischema']
 
     outdir = Path('perftest.output')
     if not outdir.exists():

--- a/perftest/realistic union of objects as namedtuple.py
+++ b/perftest/realistic union of objects as namedtuple.py
@@ -137,33 +137,6 @@ elif sys.argv[1] == '--pydantic':
     class EventListPy(pydantic.BaseModel):
         data: Tuple[EventPy, ...]
     f = lambda: EventListPy(**data)
-elif sys.argv[1] == '--msgspec':
-    import msgspec
-    class EventMessage(msgspec.Struct, tag="message"):
-        timestamp: float
-        text: str
-        sender: str
-        receiver: str
-    class EventFile(msgspec.Struct, tag="file"):
-        timestamp: float
-        filename: str
-        sender: str
-        receiver: str
-        url: str
-    class EventPing(msgspec.Struct, tag="ping"):
-        timestamp: float
-    class EventEnter(msgspec.Struct, tag="enter"):
-        timestamp: float
-        sender: str
-        room: int
-    class EventExit(msgspec.Struct, tag="exit"):
-        timestamp: float
-        sender: str
-        room: int
-    Event = Union[EventExit, EventEnter, EventMessage, EventPing, EventFile]
-    class EventList(msgspec.Struct):
-        data: Tuple[Event, ...]
-    f = lambda: msgspec.from_builtins(data, EventList)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True
@@ -194,3 +167,4 @@ assert f().data[2].sender == '3141'
 
 data = {'data': events * 50000}
 print(timeit(f))
+


### PR DESCRIPTION
Since its owner rejected the inclusion of benchmarks, after adding his
ones here.

https://github.com/jcrist/msgspec/pull/333

I'm leaving the documentation changes intact.