### PR TITLE
Support loading and dumping dates in ISO format

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 2.23
 ====
+* When loading a string into datetime.date/time/datetime, ISO 8601 is used
+* When dumping, setting `isodates=True` dumps an ISO 8601 string instead of a list of ints. The previous behaviour is now deprecated.
 * Add support for datetime.timedelta. It is dumped as a float representing seconds
 * Remove `jsons` and `dataclasses-json` from benchmarks.
   They were too slow to be a useful comparison.

--- a/docs/supported_types.md
+++ b/docs/supported_types.md
@@ -467,8 +467,16 @@ This is converted to a dictionary and can be loaded into NamedTuple/dataclass.
 Dates
 -----
 
-* `datetime.date`
-* `datetime.time`
-* `datetime.datetime`
-* `datetime.timedelta`
-  Represented as a float of seconds
+### `datetime.timedelta`
+Represented as a float of seconds.
+
+
+### `datetime.date` `datetime.time` `datetime.datetime`
+
+When loading, it is possible to pass a string in ISO 8601, or a list of ints that will be passed to the constructor.
+
+When dumping, the default is to dump a list of ints, unless `isodates=True` is set in the dumper object, in which case an ISO 8601 string will be returned instead.
+
+The format with the list of ints is deprecated and kept for backward compatibility. Everybody should use the ISO 8601 strings.
+
+The format with the list of ints does not support timezones.

--- a/tests/test_datadumper.py
+++ b/tests/test_datadumper.py
@@ -1,5 +1,5 @@
 # typedload
-# Copyright (C) 2018-2021 Salvo "LtWorf" Tomaselli
+# Copyright (C) 2018-2023 Salvo "LtWorf" Tomaselli
 #
 # typedload is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,7 +17,6 @@
 # author Salvo "LtWorf" Tomaselli <tiposchi@tiscali.it>
 
 
-import datetime
 from enum import Enum
 from ipaddress import IPv4Address, IPv4Network, IPv4Interface, IPv6Address, IPv6Network, IPv6Interface
 from pathlib import Path
@@ -108,12 +107,6 @@ class TestBasicDump(unittest.TestCase):
         with self.assertRaises(ValueError):
             assert dumper.dump(None) == None
             assert dumper.dump(True) == True
-
-    def test_datetime(self):
-        dumper = datadumper.Dumper()
-        assert dumper.dump(datetime.date(2011, 12, 12)) == [2011, 12, 12]
-        assert dumper.dump(datetime.time(15, 41)) == [15, 41, 0, 0]
-        assert dumper.dump(datetime.datetime(2019, 5, 31, 12, 44, 22)) == [2019, 5, 31, 12, 44, 22, 0]
 
 
 class TestHandlersDumper(unittest.TestCase):

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -1,5 +1,5 @@
 # typedload
-# Copyright (C) 2018-2021 Salvo "LtWorf" Tomaselli
+# Copyright (C) 2018-2023 Salvo "LtWorf" Tomaselli
 #
 # typedload is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,7 +18,6 @@
 
 
 import argparse
-import datetime
 from enum import Enum
 from ipaddress import IPv4Address, IPv6Address, IPv6Network, IPv4Network, IPv4Interface, IPv6Interface
 from pathlib import Path
@@ -409,30 +408,6 @@ class TestExceptions(unittest.TestCase):
         except Exception as e:
             assert e.value == 'q'
             assert e.type_ == int
-
-
-class TestDatetime(unittest.TestCase):
-
-    def test_date(self):
-        loader = dataloader.Loader()
-        assert loader.load((2011, 1, 1), datetime.date) == datetime.date(2011, 1, 1)
-        assert loader.load((15, 33), datetime.time) == datetime.time(15, 33)
-        assert loader.load((15, 33, 0), datetime.time) == datetime.time(15, 33)
-        assert loader.load((2011, 1, 1), datetime.datetime) == datetime.datetime(2011, 1, 1)
-        assert loader.load((2011, 1, 1, 22), datetime.datetime) == datetime.datetime(2011, 1, 1, 22)
-
-        # Same but with lists
-        assert loader.load([2011, 1, 1], datetime.date) == datetime.date(2011, 1, 1)
-        assert loader.load([15, 33], datetime.time) == datetime.time(15, 33)
-        assert loader.load([15, 33, 0], datetime.time) == datetime.time(15, 33)
-        assert loader.load([2011, 1, 1], datetime.datetime) == datetime.datetime(2011, 1, 1)
-        assert loader.load([2011, 1, 1, 22], datetime.datetime) == datetime.datetime(2011, 1, 1, 22)
-
-    def test_exception(self):
-        loader = dataloader.Loader()
-        with self.assertRaises(TypeError):
-            loader.load((2011, ), datetime.datetime)
-            loader.load(33, datetime.datetime)
 
 
 class TestDictEquivalence(unittest.TestCase):

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -22,6 +22,37 @@ import unittest
 from typedload import load, dump, dataloader, datadumper
 
 
+class TestDatetimedump(unittest.TestCase):
+    def test_datetime(self):
+        dumper = datadumper.Dumper()
+        assert dumper.dump(datetime.date(2011, 12, 12)) == [2011, 12, 12]
+        assert dumper.dump(datetime.time(15, 41)) == [15, 41, 0, 0]
+        assert dumper.dump(datetime.datetime(2019, 5, 31, 12, 44, 22)) == [2019, 5, 31, 12, 44, 22, 0]
+
+class TestDatetimeLoad(unittest.TestCase):
+
+    def test_date(self):
+        loader = dataloader.Loader()
+        assert loader.load((2011, 1, 1), datetime.date) == datetime.date(2011, 1, 1)
+        assert loader.load((15, 33), datetime.time) == datetime.time(15, 33)
+        assert loader.load((15, 33, 0), datetime.time) == datetime.time(15, 33)
+        assert loader.load((2011, 1, 1), datetime.datetime) == datetime.datetime(2011, 1, 1)
+        assert loader.load((2011, 1, 1, 22), datetime.datetime) == datetime.datetime(2011, 1, 1, 22)
+
+        # Same but with lists
+        assert loader.load([2011, 1, 1], datetime.date) == datetime.date(2011, 1, 1)
+        assert loader.load([15, 33], datetime.time) == datetime.time(15, 33)
+        assert loader.load([15, 33, 0], datetime.time) == datetime.time(15, 33)
+        assert loader.load([2011, 1, 1], datetime.datetime) == datetime.datetime(2011, 1, 1)
+        assert loader.load([2011, 1, 1, 22], datetime.datetime) == datetime.datetime(2011, 1, 1, 22)
+
+    def test_exception(self):
+        loader = dataloader.Loader()
+        with self.assertRaises(TypeError):
+            loader.load((2011, ), datetime.datetime)
+            loader.load(33, datetime.datetime)
+
+
 class TestTimedelta(unittest.TestCase):
 
     def test_findhandlers(self):

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -23,6 +23,13 @@ from typedload import load, dump, dataloader, datadumper
 
 
 class TestDatetimedump(unittest.TestCase):
+    def test_isodatetime(self):
+        dumper = datadumper.Dumper(isodates=True)
+        assert dumper.dump(datetime.date(2011, 12, 12)) == '2011-12-12'
+        assert dumper.dump(datetime.time(15, 41)) == '15:41:00'
+        assert dumper.dump(datetime.datetime(2019, 5, 31, 12, 44, 22)) == '2019-05-31T12:44:22'
+        assert dumper.dump(datetime.datetime(2023, 3, 20, 7, 43, 19, 906439, tzinfo=datetime.timezone.utc)) == '2023-03-20T07:43:19.906439+00:00'
+
     def test_datetime(self):
         dumper = datadumper.Dumper()
         assert dumper.dump(datetime.date(2011, 12, 12)) == [2011, 12, 12]
@@ -30,6 +37,18 @@ class TestDatetimedump(unittest.TestCase):
         assert dumper.dump(datetime.datetime(2019, 5, 31, 12, 44, 22)) == [2019, 5, 31, 12, 44, 22, 0]
 
 class TestDatetimeLoad(unittest.TestCase):
+    def test_isoload(self):
+        now = datetime.datetime.now()
+        assert load(now.isoformat(), datetime.datetime) == now
+
+        withtz = datetime.datetime(2023, 3, 20, 7, 43, 19, 906439, tzinfo=datetime.timezone.utc)
+        assert load(withtz.isoformat(), datetime.datetime) == withtz
+
+        date = datetime.date(2023, 4, 1)
+        assert load(date.isoformat(), datetime.date) == date
+
+        time = datetime.time(23, 44, 12)
+        assert load(time.isoformat(), datetime.time) == time
 
     def test_date(self):
         loader = dataloader.Loader()

--- a/typedload/datadumper.py
+++ b/typedload/datadumper.py
@@ -48,6 +48,15 @@ class Dumper:
         When enabled, does not include fields that have the
         same value as the default in the dump.
 
+    isodates: Disabled by default.
+        Will be enabled by default from version 3.
+        When disabled, datetime.datetime, datetime.time, datetime.date
+        are dumped as lists of ints.
+
+        When enabled they are dumped as strings in ISO 8601 format.
+
+        When enabled, timezone information will work.
+
     raiseconditionerrors: Enabled by default.
         Raises exceptions when evaluating a condition from an
         handler. When disabled, the exceptions are not raised
@@ -95,6 +104,8 @@ class Dumper:
         self.basictypes = {int, bool, float, str, NONETYPE}
 
         self.hidedefault = True
+
+        self.isodates = False
 
         # Which key is used in metadata to perform name mangling
         self.mangle_key = 'name'
@@ -196,6 +207,15 @@ def _attrdump(d, value, t) -> Dict[str, Any]:
 
 
 def _datetimedump(d: Dumper, value: Union[datetime.time, datetime.date, datetime.datetime], t):
+    if d.isodates:
+        return value.isoformat()
+    import warnings
+    warnings.warn(
+        'Dumping datetime classes as list of values is deprecated.\n'
+            'You are encouraged to dump with isodates=True\n'
+            'This will become the default in the next major version.',
+        DeprecationWarning
+    )
     # datetime is subclass of date
     if isinstance(value, datetime.date) and not isinstance(value, datetime.datetime):
         return [value.year, value.month, value.day]

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -737,9 +737,15 @@ def _noneload(l: Loader, value: Any, type_) -> None:
 
 def _datetimeload(l: Loader, value: Any, type_) -> Union[datetime.date, datetime.time, datetime.datetime]:
     try:
-        return type_(*value)
+        if isinstance(value, str):
+            return type_.fromisoformat(value)
+        else:
+            # This might be removed at some point in the future, but it will break data compatibility
+            return type_(*value)
     except TypeError as e:
         raise TypedloadTypeError(str(e), type_=type_, value=value)
+    except ValueError as e:
+        raise TypedloadValueError(str(e), type_=type_, value=value)
 
 
 def _timedeltaload(l: Loader, value, type_) -> datetime.timedelta:


### PR DESCRIPTION
The dumping of dates as list[int] that has happened until now is
deprecated, but will be kept as default until version 3, to not break
compatibility.

After that it will still be kept around but will need setting the flag
to use it.

With this, timezone support works. (Fixes: #72)