### PR TITLE
Fix mistake in test for pydantic

### DIFF
--- a/perftest/load big dictionary.py
+++ b/perftest/load big dictionary.py
@@ -37,8 +37,6 @@ elif sys.argv[1] == '--pydantic':
     class DataPy(pydantic.BaseModel):
         data: dict[str, dict[int, str]]
     f = lambda: DataPy(**data)
-    assert f().data['0'][0] == '0'
-    print(timeit(f))
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True


### PR DESCRIPTION
I had an out of place assert. The test should have passed.

![3 11_load_big_dictionary](https://user-images.githubusercontent.com/1379609/235348899-7ce3a83b-18fc-4e9b-9ffe-5b77552455dd.svg)

The name of the branch is wrong. I had set out to benchmark against pydantic2 but since it is API incompatible with the current, I can't benchmark both, so I will switch to that once it's actually released.
