### PR TITLE
Keep track of the index when loading iterators

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 ====
 * Drop support to Python 3.7 (which has reached EOL)
 * Make is_optional slightly faster
+* Keep track of the index when loading iterables the first time
+  It makes the normal case slightly slower, and gives massive performance
+  improvements when exceptions are raised.
 
 2.23
 ====

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -845,9 +845,9 @@ def _iterload(l: Loader, value: Any, type_, function) -> Any:
     # Use the handler
     try:
         # Hopeful load calling the handler directly, skipping load()
-        return function(f(l, v, (t, index:=i)[0]) for i, v in enumerate(value))
+        return function(f(l, v, t) for i, v in enumerate(value) if (index:= i+1))
     except TypedloadException as e:
-        annotation = Annotation(AnnotationType.INDEX, index)
+        annotation = Annotation(AnnotationType.INDEX, index - 1)
         e.trace.insert(0, TraceItem(value, type_, annotation))
         raise e
     except TypeError as e:

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -842,9 +842,8 @@ def _iterload(l: Loader, value: Any, type_, function) -> Any:
                 type_=type_
             )
 
-    # Use the handler
+    # load calling the handler directly, skipping load()
     try:
-        # Hopeful load calling the handler directly, skipping load()
         return function(f(l, v, t) for i, v in enumerate(value) if (index:= i+1))
     except TypedloadException as e:
         annotation = Annotation(AnnotationType.INDEX, index - 1)

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -844,7 +844,7 @@ def _iterload(l: Loader, value: Any, type_, function) -> Any:
 
     # load calling the handler directly, skipping load()
     try:
-        return function(f(l, v, t) for i, v in enumerate(value) if (index:= i+1))
+        return function(f(l, v, t) for i, v in enumerate(value, 1) if (index:= i))
     except TypedloadException as e:
         annotation = Annotation(AnnotationType.INDEX, index - 1)
         e.trace.insert(0, TraceItem(value, type_, annotation))


### PR DESCRIPTION
This is to be able to use it quickly in case an exception is raised,
rather than having to re-run the whole thing.

Which, now that I think of it, might not work, because I check for
generators, but not for nested generators.

As it is, this slows things down a bit. I have to see if there's something faster than enumerate.