### PR TITLE
Faster object loading

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 2.25
 ====
+* Improve performances for loading objects (attrs/dataclasses/NamedTuple)
 
 2.24
 ====

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -531,19 +531,19 @@ def _objloader(l: Loader, fields: Set[str], necessary_fields: Set[str], type_hin
             type_=type_,
         )
 
+    if l.failonextra and len(extra_fields := vfields.difference(fields)):
+        extra = ', '.join(extra_fields)
+        raise TypedloadValueError(
+            'Dictionary has unrecognized fields: %s and cannot be loaded into %s' % (extra, tname(type_)),
+            value=value,
+            type_=type_,
+        )
+
     params = {}
     for k, v in value.items():
         if k not in fields:
             # Field in value is not in the type
-            if l.failonextra:
-                extra = ', '.join(vfields.difference(fields))
-                raise TypedloadValueError(
-                    'Dictionary has unrecognized fields: %s and cannot be loaded into %s' % (extra, tname(type_)),
-                    value=value,
-                    type_=type_,
-                )
-            else:
-                continue
+            continue
         params[k] = l.load(
             v,
             type_hints[k],

--- a/typedload/dataloader.py
+++ b/typedload/dataloader.py
@@ -838,12 +838,10 @@ def _iterload(l: Loader, value: Any, type_, function) -> Any:
             f = l._indexcache[t] = l.handlers[l.index(t)][1]
         except ValueError:
             raise TypedloadTypeError(
-                'Cannot deal with value of type %s' % tname(type_),
+                'Cannot deal with value of type %s' % tname(t),
                 value=value,
-                type_=type_
+                type_=t,
             )
-
-
 
     # load calling the handler directly, skipping load()
     try:


### PR DESCRIPTION
Check for extra fields all at once, skip calling load() and call the handler directly.