### PR TITLE
Switch to using Pydantic `TypeAdapter`

### DIFF
--- a/perftest/dump objects.py
+++ b/perftest/dump objects.py
@@ -49,9 +49,8 @@ elif sys.argv[1] == '--jsons':
     f = lambda: dump(data)
 elif sys.argv[1] == '--pydantic':
     import pydantic
-    class PPossessions(pydantic.BaseModel):
-        possessions: list[Union[House, Car]]
-    f = lambda: PPossessions(possessions=data.possessions).dict()
+    ta = pydantic.TypeAdapter(list[Union[House, Car]])
+    f = lambda: ta.dump_python(data.possessions)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/fail load list of floats and ints.py
+++ b/perftest/fail load list of floats and ints.py
@@ -34,9 +34,8 @@ if sys.argv[1] == '--jsons':
     f = lambda: load(data, Data)
 elif sys.argv[1] == '--pydantic':
     import pydantic
-    class DataPy(pydantic.BaseModel):
-        data: List[Union[int, float]]
-    f = lambda: DataPy(**data)
+    ta = pydantic.TypeAdapter(Data)
+    f = lambda: ta.validate_python(data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/fail realistic union of objects as namedtuple.py
+++ b/perftest/fail realistic union of objects as namedtuple.py
@@ -107,36 +107,8 @@ elif sys.argv[1] == '--jsons':
     f = lambda: load(data, EventList)
 elif sys.argv[1] == '--pydantic':
     import pydantic
-    class EventMessagePy(pydantic.BaseModel):
-        timestamp: float
-        type: Literal['message']
-        text: str
-        sender: str
-        receiver: str
-    class EventFilePy(pydantic.BaseModel):
-        timestamp: float
-        type: Literal['file']
-        filename: str
-        sender: str
-        receiver: str
-        url: str
-    class EventPingPy(pydantic.BaseModel):
-        timestamp: float
-        type: Literal['ping']
-    class EventEnterPy(pydantic.BaseModel):
-        type: Literal['enter']
-        timestamp: float
-        sender: str
-        room: int
-    class EventExitPy(pydantic.BaseModel):
-        type: Literal['exit']
-        timestamp: float
-        sender: str
-        room: int
-    EventPy = Union[EventExitPy, EventEnterPy,EventMessagePy, EventPingPy, EventFilePy]
-    class EventListPy(pydantic.BaseModel):
-        data: Tuple[EventPy, ...]
-    f = lambda: EventListPy(**data)
+    ta = pydantic.TypeAdapter(EventList)
+    f = lambda: ta.validate_python(data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load big dictionary.py
+++ b/perftest/load big dictionary.py
@@ -34,9 +34,8 @@ elif sys.argv[1] == '--jsons':
     f = lambda: load(data, Data)
 elif sys.argv[1] == '--pydantic':
     import pydantic
-    class DataPy(pydantic.BaseModel):
-        data: dict[str, dict[int, str]]
-    f = lambda: DataPy(**data)
+    ta = pydantic.TypeAdapter(Data)
+    f = lambda: ta.validate_python(data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load list of NamedTuple objects.py
+++ b/perftest/load list of NamedTuple objects.py
@@ -39,11 +39,8 @@ elif sys.argv[1] == '--jsons':
     f = lambda: load(data, Data)
 elif sys.argv[1] == '--pydantic':
     import pydantic
-    class ChildPy(pydantic.BaseModel):
-        value: int
-    class DataPy(pydantic.BaseModel):
-        data: List[ChildPy]
-    f = lambda: DataPy(**data)
+    ta = pydantic.TypeAdapter(Data)
+    f = lambda: ta.validate_python(data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load list of attrs objects.py
+++ b/perftest/load list of attrs objects.py
@@ -41,11 +41,8 @@ if sys.argv[1] == '--typedload':
     print(timeit(lambda: load(data, Data)))
 elif sys.argv[1] == '--pydantic':
     import pydantic
-    class ChildPy(pydantic.BaseModel):
-        value: int
-    class DataPy(pydantic.BaseModel):
-        data: List[ChildPy]
-    print(timeit(lambda: DataPy(**data)))
+    ta = pydantic.TypeAdapter(data)
+    print(timeit(lambda: ta.validate_python(data)))
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load list of dataclass objects.py
+++ b/perftest/load list of dataclass objects.py
@@ -35,17 +35,9 @@ if sys.argv[1] == '--typedload':
     from typedload import load
     f = lambda: load(data, Data)
 elif sys.argv[1] == '--pydantic':
-    # Yes pydantic supports dataclasses by having a decorator with the same name as the python one -_-'
-    from pydantic.dataclasses import dataclass as dc
-
-    @dc
-    class ChildPy:
-        value: int
-
-    @dc
-    class DataPy:
-        data: list[ChildPy]
-    f = lambda: DataPy(**data)
+    import pydantic
+    ta = pydantic.TypeAdapter(Data)
+    f = lambda: ta.validate_python(data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load list of floats and ints.py
+++ b/perftest/load list of floats and ints.py
@@ -34,9 +34,8 @@ if sys.argv[1] == '--jsons':
     f = lambda: load(data, Data)
 elif sys.argv[1] == '--pydantic':
     import pydantic
-    class DataPy(pydantic.BaseModel):
-        data: List[Union[int, float]]
-    f = lambda: DataPy(**data)
+    ta = pydantic.TypeAdapter(Data)
+    f = lambda: ta.validate_python(data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load list of ints.py
+++ b/perftest/load list of ints.py
@@ -34,9 +34,8 @@ elif sys.argv[1] == '--jsons':
     f = lambda: load(data, Data)
 elif sys.argv[1] == '--pydantic':
     import pydantic
-    class DataPy(pydantic.BaseModel):
-        data: List[int]
-    f = lambda: DataPy(**data)
+    ta = pydantic.TypeAdapter(Data)
+    f = lambda: ta.validate_python(data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load list of lists.py
+++ b/perftest/load list of lists.py
@@ -34,9 +34,8 @@ elif sys.argv[1] == '--jsons':
     f = lambda: load(data, Data)
 elif sys.argv[1] == '--pydantic':
     import pydantic
-    class DataPy(pydantic.BaseModel):
-        data: list[list[int]]
-    f = lambda: DataPy(**data)
+    ta = pydantic.TypeAdapter(Data)
+    f = lambda: ta.validate_python(data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/realistic union of objects as namedtuple.py
+++ b/perftest/realistic union of objects as namedtuple.py
@@ -107,36 +107,8 @@ elif sys.argv[1] == '--jsons':
     f = lambda: load(data, EventList)
 elif sys.argv[1] == '--pydantic':
     import pydantic
-    class EventMessagePy(pydantic.BaseModel):
-        timestamp: float
-        type: Literal['message']
-        text: str
-        sender: str
-        receiver: str
-    class EventFilePy(pydantic.BaseModel):
-        timestamp: float
-        type: Literal['file']
-        filename: str
-        sender: str
-        receiver: str
-        url: str
-    class EventPingPy(pydantic.BaseModel):
-        timestamp: float
-        type: Literal['ping']
-    class EventEnterPy(pydantic.BaseModel):
-        type: Literal['enter']
-        timestamp: float
-        sender: str
-        room: int
-    class EventExitPy(pydantic.BaseModel):
-        type: Literal['exit']
-        timestamp: float
-        sender: str
-        room: int
-    EventPy = Union[EventExitPy, EventEnterPy,EventMessagePy, EventPingPy, EventFilePy]
-    class EventListPy(pydantic.BaseModel):
-        data: Tuple[EventPy, ...]
-    f = lambda: EventListPy(**data)
+    ta = pydantic.TypeAdapter(EventList)
+    f = lambda: ta.validate_python(data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True


### PR DESCRIPTION
Hi, I noticed a few of your comments on HN @ltworf about typedload still being faster than Pydantic V2 in a few benchmarks, so I decided to have a look at the benchmarks here.

Even without these changes, I couldn't see a benchmark that was faster with typedload. Any chance you could let me know what that benchmark was?

I updated these benchmarks to use [`TypeAdapter`](https://docs.pydantic.dev/latest/usage/models/#typeadapter) mostly to make the benchmark code cleaner. It should make a significant difference with the `dump objects.py` benchmark where we're now just doing serialization, not validation and serialization.

---

More generally, please can I gently encourage a more friendly and collaborate tone of competition?

I understand that you want to promote your library, and use comparisons to Pydantic to do that - that's fine with me. 

We're both just trying to tell people about the things we've built - let's do that in a fair and civil way.

I'm sorry about the frustration with pydantic's own benchmarks, I'm sure we (I) could have dealt with it better, but I think we ended up removing doing the right thing - removing them completely.

---

Let me know what you think, and particularly if you have any ideas about how to make Pydantic faster - would love to hear your thoughts!