### PR TITLE
Use TypeAdapter to benchmark pydantic

### DIFF
--- a/perftest/fail load list of floats and ints.py
+++ b/perftest/fail load list of floats and ints.py
@@ -34,9 +34,8 @@ if sys.argv[1] == '--jsons':
     f = lambda: load(data, Data)
 elif sys.argv[1] == '--pydantic':
     import pydantic
-    class DataPy(pydantic.BaseModel):
-        data: List[Union[int, float]]
-    f = lambda: DataPy(**data)
+    ta = pydantic.TypeAdapter(Data)
+    f = lambda: ta.validate_python(data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load big dictionary.py
+++ b/perftest/load big dictionary.py
@@ -34,9 +34,8 @@ elif sys.argv[1] == '--jsons':
     f = lambda: load(data, Data)
 elif sys.argv[1] == '--pydantic':
     import pydantic
-    class DataPy(pydantic.BaseModel):
-        data: dict[str, dict[int, str]]
-    f = lambda: DataPy(**data)
+    ta = pydantic.TypeAdapter(Data)
+    f = lambda: ta.validate_python(data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load list of attrs objects.py
+++ b/perftest/load list of attrs objects.py
@@ -41,11 +41,8 @@ if sys.argv[1] == '--typedload':
     print(timeit(lambda: load(data, Data)))
 elif sys.argv[1] == '--pydantic':
     import pydantic
-    class ChildPy(pydantic.BaseModel):
-        value: int
-    class DataPy(pydantic.BaseModel):
-        data: List[ChildPy]
-    print(timeit(lambda: DataPy(**data)))
+    ta = pydantic.TypeAdapter(data)
+    print(timeit(lambda: ta.validate_python(data)))
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load list of dataclass objects.py
+++ b/perftest/load list of dataclass objects.py
@@ -35,17 +35,9 @@ if sys.argv[1] == '--typedload':
     from typedload import load
     f = lambda: load(data, Data)
 elif sys.argv[1] == '--pydantic':
-    # Yes pydantic supports dataclasses by having a decorator with the same name as the python one -_-'
-    from pydantic.dataclasses import dataclass as dc
-
-    @dc
-    class ChildPy:
-        value: int
-
-    @dc
-    class DataPy:
-        data: list[ChildPy]
-    f = lambda: DataPy(**data)
+    import pydantic
+    ta = pydantic.TypeAdapter(Data)
+    f = lambda: ta.validate_python(data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load list of floats and ints.py
+++ b/perftest/load list of floats and ints.py
@@ -34,9 +34,8 @@ if sys.argv[1] == '--jsons':
     f = lambda: load(data, Data)
 elif sys.argv[1] == '--pydantic':
     import pydantic
-    class DataPy(pydantic.BaseModel):
-        data: List[Union[int, float]]
-    f = lambda: DataPy(**data)
+    ta = pydantic.TypeAdapter(Data)
+    f = lambda: ta.validate_python(data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load list of ints.py
+++ b/perftest/load list of ints.py
@@ -34,9 +34,8 @@ elif sys.argv[1] == '--jsons':
     f = lambda: load(data, Data)
 elif sys.argv[1] == '--pydantic':
     import pydantic
-    class DataPy(pydantic.BaseModel):
-        data: List[int]
-    f = lambda: DataPy(**data)
+    ta = pydantic.TypeAdapter(Data)
+    f = lambda: ta.validate_python(data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True

--- a/perftest/load list of lists.py
+++ b/perftest/load list of lists.py
@@ -34,9 +34,8 @@ elif sys.argv[1] == '--jsons':
     f = lambda: load(data, Data)
 elif sys.argv[1] == '--pydantic':
     import pydantic
-    class DataPy(pydantic.BaseModel):
-        data: list[list[int]]
-    f = lambda: DataPy(**data)
+    ta = pydantic.TypeAdapter(Data)
+    f = lambda: ta.validate_python(data)
 elif sys.argv[1] == '--apischema':
     import apischema
     apischema.settings.serialization.check_type = True


### PR DESCRIPTION
From https://github.com/ltworf/typedload/pull/422
but keep using BaseModel instead of NamedTuple

This is because from a quick github search, it seems that BaseModel
is used in 181000 files and TypeAdapter in 344.

So it would not be so indicative to benchmark something that is not
documented and nobody seems to be using.