### PR TITLE
Add re.Pattern to remaining docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The following things are supported:
  * Literal
  * TypedDict
  * datetime.date, datetime.time, datetime.datetime
+ * re.Pattern
  * Path
  * IPv4Address, IPv6Address
  * typing.Any

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 2.27
 ====
-* Add support for regex Patterns
+* Add support for re.Patterns
 
 2.26
 ====

--- a/typedload/__init__.py
+++ b/typedload/__init__.py
@@ -71,6 +71,7 @@ There is support for:
     * attrs
     * TypedDict
     * datetime
+    * re.Pattern
     * Path
     * IPv4Address, IPv6Address
 


### PR DESCRIPTION
Update the existing reference to avoid any possible confusion with the `regex` package from PyPI: https://pypi.org/project/regex/.
Follow-up to https://github.com/ltworf/typedload/pull/439.